### PR TITLE
Remove old snapshot params

### DIFF
--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -550,9 +550,6 @@ class MapView extends React.Component {
           config.width,
           config.height,
           config.region,
-          config.format,
-          config.quality,
-          config.result,
           (err, snapshot) => {
             if (err) {
               reject(err);


### PR DESCRIPTION
The ios function expects 5 params but the component still sends 8 so this PR fixes the snapshot.