### PR TITLE
Feature/canvas android

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>react-native-maps</name>
+	<comment>Project react-native-maps created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/.settings/org.eclipse.buildship.core.prefs
+++ b/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,3 @@
+connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
+connection.project.dir=
+eclipse.preferences.version=1

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.1'
+    classpath 'com.android.tools.build:gradle:2.3.2'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.0'
+    classpath 'com.android.tools.build:gradle:2.3.1'
   }
 }
 

--- a/example/App.js
+++ b/example/App.js
@@ -123,6 +123,7 @@ class App extends React.Component {
   render() {
     return this.renderExamples([
       // [<component>, <component description>, <Google compatible>, <Google add'l description>]
+      [CustomTiles, 'Custom Tiles', true],
       [StaticMap, 'StaticMap', true],
       [DisplayLatLng, 'Tracking Position', true, '(incomplete)'],
       [ViewsAsMarkers, 'Arbitrary Views as Markers', true],
@@ -143,7 +144,6 @@ class App extends React.Component {
       [FitToSuppliedMarkers, 'Focus Map On Markers', true],
       [FitToCoordinates, 'Fit Map To Coordinates', true],
       [LiteMapView, 'Android Lite MapView'],
-      [CustomTiles, 'Custom Tiles', true],
       [ZIndexMarkers, 'Position Markers with Z-index', true],
       [MapStyle, 'Customize the style of the map', true],
       [LegalLabel, 'Reposition the legal label', true],

--- a/example/android/app/.classpath
+++ b/example/android/app/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
+	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/example/android/app/.project
+++ b/example/android/app/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>example-android</name>
+	<comment>Project example-android created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/example/android/app/.settings/org.eclipse.buildship.core.prefs
+++ b/example/android/app/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,3 @@
+connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
+connection.project.dir=../../..
+eclipse.preferences.version=1

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
 
     <uses-sdk android:minSdkVersion="16" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
 
     <application
       android:allowBackup="true"

--- a/example/examples/CustomTiles.js
+++ b/example/examples/CustomTiles.js
@@ -116,9 +116,10 @@ class CustomTiles extends React.Component {
             zIndex={-1}
             maxZoom={12}
             areaId="Download"
+            alertType="umd_as_it_happen"
             isConnected
-            minDate="2017/01/01"
-            maxDate="2017/03/01"
+            minDate="0"
+            maxDate="3000"
           />
           {hasCoordinates &&
             <MapView.CanvasInteractionUrlTile
@@ -127,9 +128,10 @@ class CustomTiles extends React.Component {
               zIndex={-1}
               maxZoom={12}
               areaId="Download"
+              alertType="umd_as_it_happen"
               isConnected
-              minDate="2017/01/01"
-              maxDate="2017/03/01"
+              minDate="0"
+              maxDate="3000"
             />
           }
         </MapView>

--- a/example/examples/CustomTiles.js
+++ b/example/examples/CustomTiles.js
@@ -27,9 +27,8 @@ class CustomTiles extends React.Component {
 
     this.state = {
       coordinates: {
-        latitude: null,
-        longitude: null,
-        tile: [], // tile coordinates x, y, z
+        tile: [], // tile coordinates x, y, z + precision x, y
+        precision: [], // tile precision x, y
       },
       region: {
         latitude: LATITUDE,
@@ -73,19 +72,20 @@ class CustomTiles extends React.Component {
   onMapPress = (e) => {
     const coordinates = e.nativeEvent.coordinate;
     const zoom = this.getMapZoom();
-    const tile = tilebelt.pointToTile(coordinates.longitude, coordinates.latitude, zoom);
+    const tile = tilebelt.pointToTile(coordinates.longitude, coordinates.latitude, zoom, true);
+
     this.setState({
       coordinates: {
-        ...coordinates,
-        tile,
+        tile: [tile[0], tile[1], tile[2]],
+        precision: [tile[3], tile[4]],
       },
     });
   }
 
   render() {
     const { region, coordinates } = this.state;
-    const hasCoordinates = (coordinates.latitude && coordinates.longitude && coordinates.tile !== null) || false;
-
+    const hasCoordinates = (coordinates.tile && coordinates.tile.length > 0) || false;
+    console.log(coordinates);
     return (
       <View style={styles.container}>
         <MapView
@@ -101,7 +101,7 @@ class CustomTiles extends React.Component {
             urlTemplate="http://wri-tiles.s3.amazonaws.com/glad_prod/tiles/{z}/{x}/{y}.png"
             zIndex={-1}
             maxZoom={12}
-            areaName="Download"
+            areaId="Download"
             isConnected
             minDate="2017/01/01"
             maxDate="2017/03/01"
@@ -112,7 +112,7 @@ class CustomTiles extends React.Component {
               urlTemplate="http://wri-tiles.s3.amazonaws.com/glad_prod/tiles/{z}/{x}/{y}.png"
               zIndex={-1}
               maxZoom={12}
-              areaName="Download"
+              areaId="Download"
               isConnected
               minDate="2017/01/01"
               maxDate="2017/03/01"

--- a/example/examples/CustomTiles.js
+++ b/example/examples/CustomTiles.js
@@ -98,7 +98,7 @@ class CustomTiles extends React.Component {
   render() {
     const { region, coordinates } = this.state;
     const hasCoordinates = (coordinates.tile && coordinates.tile.length === 3) || false;
-    console.log(coordinates);
+
     return (
       <View style={styles.container}>
         <MapView

--- a/example/examples/CustomTiles.js
+++ b/example/examples/CustomTiles.js
@@ -62,11 +62,20 @@ class CustomTiles extends React.Component {
       position.latitude + (position.latitudeDelta / 2),
     ];
 
-    return geoViewport.viewport(bounds, [height, width]).zoom || null;
+    return geoViewport.viewport(bounds, [width, height], 0, 21, 256).zoom || 0;
+  }
+
+  onRegionChangeComplete = (region) => {
+    this.updateRegion(region);
   }
 
   onRegionChange = (region) => {
-    this.setState({ region });
+    if (this.onRegionChangeTimer) {
+      clearTimeout(this.onRegionChangeTimer);
+    }
+    this.onRegionChangeTimer = setTimeout(() => {
+      this.updateRegion(region);
+    }, 200);
   }
 
   onMapPress = (e) => {
@@ -82,9 +91,13 @@ class CustomTiles extends React.Component {
     });
   }
 
+  updateRegion = (region) => {
+    this.setState({ region });
+  }
+
   render() {
     const { region, coordinates } = this.state;
-    const hasCoordinates = (coordinates.tile && coordinates.tile.length > 0) || false;
+    const hasCoordinates = (coordinates.tile && coordinates.tile.length === 3) || false;
     console.log(coordinates);
     return (
       <View style={styles.container}>
@@ -95,7 +108,8 @@ class CustomTiles extends React.Component {
           mapType="hybrid"
           onPress={this.onMapPress}
           initialRegion={region}
-          onRegionChangeComplete={this.onRegionChange}
+          onRegionChange={this.onRegionChange}
+          onRegionChangeComplete={this.onRegionChangeComplete}
         >
           <MapView.CanvasUrlTile
             urlTemplate="http://wri-tiles.s3.amazonaws.com/glad_prod/tiles/{z}/{x}/{y}.png"

--- a/example/examples/CustomTiles.js
+++ b/example/examples/CustomTiles.js
@@ -4,6 +4,8 @@ import {
   View,
   Text,
   Dimensions,
+  Platform,
+  PermissionsAndroid,
 } from 'react-native';
 
 import MapView, { MAP_TYPES, PROVIDER_DEFAULT } from 'react-native-maps';
@@ -11,9 +13,9 @@ import MapView, { MAP_TYPES, PROVIDER_DEFAULT } from 'react-native-maps';
 const { width, height } = Dimensions.get('window');
 
 const ASPECT_RATIO = width / height;
-const LATITUDE = -9.020726;
-const LONGITUDE = -52.467347;
-const LATITUDE_DELTA = 40.1922;
+const LATITUDE = -8.380882;
+const LONGITUDE = -74.448166;
+const LATITUDE_DELTA = 0.2222;
 const LONGITUDE_DELTA = LATITUDE_DELTA * ASPECT_RATIO;
 
 class CustomTiles extends React.Component {
@@ -35,6 +37,14 @@ class CustomTiles extends React.Component {
     return this.props.provider === PROVIDER_DEFAULT ?
       MAP_TYPES.STANDARD : MAP_TYPES.NONE;
   }
+
+  componentDidMount() {
+    if (Platform.OS === 'android') {
+      PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.READ_EXTERNAL_STORAGE);
+      PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE);
+    }
+  }
+
 
   render() {
     const { region } = this.state;

--- a/example/examples/CustomTiles.js
+++ b/example/examples/CustomTiles.js
@@ -11,9 +11,9 @@ import MapView, { MAP_TYPES, PROVIDER_DEFAULT } from 'react-native-maps';
 const { width, height } = Dimensions.get('window');
 
 const ASPECT_RATIO = width / height;
-const LATITUDE = 37.78825;
-const LONGITUDE = -122.4324;
-const LATITUDE_DELTA = 0.0922;
+const LATITUDE = -9.020726;
+const LONGITUDE = -52.467347;
+const LATITUDE_DELTA = 40.1922;
 const LONGITUDE_DELTA = LATITUDE_DELTA * ASPECT_RATIO;
 
 class CustomTiles extends React.Component {
@@ -46,8 +46,8 @@ class CustomTiles extends React.Component {
           style={styles.map}
           initialRegion={region}
         >
-          <MapView.UrlTile
-            urlTemplate="http://c.tile.stamen.com/watercolor/{z}/{x}/{y}.jpg"
+          <MapView.CanvasUrlTile
+            urlTemplate="http://wri-tiles.s3.amazonaws.com/glad_prod/tiles/{z}/{x}/{y}.png"
             zIndex={-1}
           />
         </MapView>

--- a/example/examples/CustomTiles.js
+++ b/example/examples/CustomTiles.js
@@ -54,11 +54,17 @@ class CustomTiles extends React.Component {
           provider={this.props.provider}
           mapType={this.mapType}
           style={styles.map}
+          mapType="hybrid"
           initialRegion={region}
         >
           <MapView.CanvasUrlTile
             urlTemplate="http://wri-tiles.s3.amazonaws.com/glad_prod/tiles/{z}/{x}/{y}.png"
             zIndex={-1}
+            maxZoom={12}
+            areaName="Download"
+            isConnected={false}
+            minDate="2017/01/01"
+            maxDate="2017/03/01"
           />
         </MapView>
         <View style={styles.buttonContainer}>

--- a/lib/android/.classpath
+++ b/lib/android/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
+	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/lib/android/.project
+++ b/lib/android/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>react-native-maps-lib</name>
+	<comment>Project react-native-maps-lib created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/lib/android/.settings/org.eclipse.buildship.core.prefs
+++ b/lib/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,3 @@
+connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
+connection.project.dir=../..
+eclipse.preferences.version=1

--- a/lib/android/gradle.properties
+++ b/lib/android/gradle.properties
@@ -16,3 +16,4 @@ POM_DEVELOPER_NAME=Leland Richardson
 POM_NAME=ReactNative Maps library
 POM_ARTIFACT_ID=react-native-maps
 POM_PACKAGING=aar
+org.gradle.jvmargs=-Xmx2048m

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasFeature.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasFeature.java
@@ -1,0 +1,131 @@
+package com.airbnb.android.react.maps;
+
+import android.content.Context;
+
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.TileOverlay;
+import com.google.android.gms.maps.model.TileOverlayOptions;
+
+/**
+ * Created by joseangel.parreno@vizzuality.com on 25/05/2017.
+ */
+
+public abstract class AirMapCanvasFeature extends AirMapFeature {
+    protected TileOverlayOptions tileOverlayOptions;
+    protected TileOverlay tileOverlay;
+    protected AirMapCanvasTileProvider tileProvider;
+
+    protected String urlTemplate;
+    protected int maxZoom;
+    protected String areaId;
+    protected String alertType;
+    protected String minDate;
+    protected String maxDate;
+    protected boolean isConnected;
+    protected float zIndex;
+    protected Coordinates coordinates;
+
+    public AirMapCanvasFeature(Context context) {
+        super(context);
+    }
+
+    public void setUrlTemplate(String urlTemplate) {
+        this.urlTemplate = urlTemplate;
+        if (tileProvider != null) {
+            tileProvider.setUrlTemplate(urlTemplate);
+        }
+        if (tileOverlay != null) {
+            tileOverlay.clearTileCache();
+        }
+    }
+
+    public void setMaxZoom(int maxZoom) {
+        this.maxZoom = maxZoom;
+        if (tileProvider != null) {
+            tileProvider.setMaxZoom(maxZoom);
+        }
+        if (tileOverlay != null) {
+            tileOverlay.clearTileCache();
+        }
+    }
+
+    public void setAreaId(String areaId) {
+        this.areaId = areaId;
+        if (tileProvider != null) {
+            tileProvider.setAreaId(areaId);
+        }
+        if (tileOverlay != null) {
+            tileOverlay.clearTileCache();
+        }
+    }
+
+    public void setIsConnected(boolean isConnected) {
+        this.isConnected = isConnected;
+        if (tileProvider != null) {
+            tileProvider.setIsConnected(isConnected);
+        }
+        if (tileOverlay != null) {
+            tileOverlay.clearTileCache();
+        }
+    }
+
+    public void setAlertType(String alertType) {
+        this.alertType = alertType;
+        if (tileProvider != null) {
+            tileProvider.setAlertType(alertType);
+        }
+        if (tileOverlay != null) {
+            tileOverlay.clearTileCache();
+        }
+    }
+
+    public void setMinDate(String minDate) {
+        this.minDate = minDate;
+    }
+
+    public void setMaxDate(String maxDate) {
+        this.maxDate = maxDate;
+    }
+
+    public void setZIndex(float zIndex) {
+        this.zIndex = zIndex;
+        if (tileOverlay != null) {
+            tileOverlay.setZIndex(zIndex);
+        }
+    }
+
+    public void setCoordinates(Coordinates coordinates) {
+        this.coordinates = coordinates;
+        if (tileProvider != null) {
+            tileProvider.setCoordinates(coordinates);
+        }
+        if (tileOverlay != null) {
+            tileOverlay.clearTileCache();
+        }
+    }
+
+    public TileOverlayOptions getTileOverlayOptions() {
+        if (tileOverlayOptions == null) {
+            tileOverlayOptions = createTileOverlayOptions();
+        }
+        return tileOverlayOptions;
+    }
+
+    protected abstract TileOverlayOptions createTileOverlayOptions();
+
+
+    @Override
+    public Object getFeature() {
+        return tileOverlay;
+    }
+
+    @Override
+    public void addToMap(GoogleMap map) {
+        this.tileOverlay = map.addTileOverlay(getTileOverlayOptions());
+    }
+
+    @Override
+    public void removeFromMap(GoogleMap map) {
+        tileOverlay.remove();
+    }
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasInteractionUrlTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasInteractionUrlTile.java
@@ -44,15 +44,19 @@ public class AirMapCanvasInteractionUrlTile extends AirMapFeature {
         private int height;
         private int maxZoom;
         private String areaId;
+        private String minDate;
+        private String maxDate;
         private boolean isConnected;
         private Coordinates coordinates;
-        public AIRMapCanvasInteractionUrlTileProvider(int width, int height, String urlTemplate, int maxZoom, String areaId, boolean isConnected, Coordinates coordinates) {
+        public AIRMapCanvasInteractionUrlTileProvider(int width, int height, String urlTemplate, int maxZoom, String areaId, boolean isConnected, String minDate, String maxDate, Coordinates coordinates) {
             super();
             this.width = width;
             this.height = height;
             this.urlTemplate = urlTemplate;
             this.maxZoom = maxZoom;
             this.areaId = areaId;
+            this.minDate = minDate;
+            this.maxDate = maxDate;
             this.isConnected = isConnected;
             this.coordinates = coordinates;
         }
@@ -68,6 +72,10 @@ public class AirMapCanvasInteractionUrlTile extends AirMapFeature {
             int srcW = this.width;
             int srcH = this.height;
             int scaleSize = 1;
+
+            int minDate = Integer.valueOf(this.minDate);
+            int maxDate = Integer.valueOf(this.maxDate);
+
             int[] tile = coordinates.getTile();
             Log.d("tile Position: ", x + "-" + y + "-" + zoom);
             Log.d("tile given: ", tile[0] + "-" + tile[1] + "-" + tile[2]);
@@ -161,9 +169,10 @@ public class AirMapCanvasInteractionUrlTile extends AirMapFeature {
                             green = 255;
 
                         int day = red * 255 + green;
+                        boolean inDay = day > 0 && day >= minDate && day <= maxDate;
+                        boolean inPoint = xPoint == xFilter && yPoint == yFilter;
 
-                        // if (day > 0 && day >= minDate && day <= maxDate) {
-                        if (xPoint == xFilter && yPoint == yFilter) {
+                        if (inDay && inPoint) {
                             red = 255;
                             green = 255;
                             blue = 255;
@@ -271,7 +280,7 @@ public class AirMapCanvasInteractionUrlTile extends AirMapFeature {
     }
 
     public void setMaxDate(String maxDate) {
-        this.minDate = maxDate;
+        this.maxDate = maxDate;
     }
 
     public void setZIndex(float zIndex) {
@@ -301,7 +310,7 @@ public class AirMapCanvasInteractionUrlTile extends AirMapFeature {
     private TileOverlayOptions createTileOverlayOptions() {
         TileOverlayOptions options = new TileOverlayOptions();
         options.zIndex(zIndex);
-        this.tileProvider = new AIRMapCanvasInteractionUrlTileProvider(256, 256, this.urlTemplate, this.maxZoom, this.areaId, this.isConnected, this.coordinates);
+        this.tileProvider = new AIRMapCanvasInteractionUrlTileProvider(256, 256, this.urlTemplate, this.maxZoom, this.areaId, this.isConnected, this.minDate, this.maxDate, this.coordinates);
         options.tileProvider(this.tileProvider);
         // options.fadeIn(false);
         return options;

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasInteractionUrlTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasInteractionUrlTile.java
@@ -83,9 +83,9 @@ public class AirMapCanvasInteractionUrlTile extends AirMapFeature {
             if (tile[0] == x && tile[1] == y && tile[2] == zoom) {
 
                 if (zoom > this.maxZoom) {
-                  xCord = (int)(x / (Math.pow(2, zoom - this.maxZoom)));
-                  yCord = (int)(y / (Math.pow(2, zoom - this.maxZoom)));
-                  zoomCord = this.maxZoom;
+                    xCord = (int)(x / (Math.pow(2, zoom - this.maxZoom)));
+                    yCord = (int)(y / (Math.pow(2, zoom - this.maxZoom)));
+                    zoomCord = this.maxZoom;
                 }
 
                 ByteArrayOutputStream stream = new ByteArrayOutputStream();
@@ -94,44 +94,45 @@ public class AirMapCanvasInteractionUrlTile extends AirMapFeature {
                 Bitmap image;
 
                 if (this.isConnected) {
-                  String providerUrl = this.urlTemplate
-                    .replace("{x}", Integer.toString(xCord))
-                    .replace("{y}", Integer.toString(yCord))
-                    .replace("{z}", Integer.toString(zoomCord));
+                    String providerUrl = this.urlTemplate
+                            .replace("{x}", Integer.toString(xCord))
+                            .replace("{y}", Integer.toString(yCord))
+                            .replace("{z}", Integer.toString(zoomCord));
 
-                  URL url;
-                  try {
-                      url = new URL(providerUrl);
-                      image = BitmapFactory.decodeStream(url.openConnection().getInputStream());
-                  } catch (Exception e) {
-                      e.printStackTrace();
-                      return NO_TILE;
-                  }
+                    URL url;
+                    try {
+                        url = new URL(providerUrl);
+                        image = BitmapFactory.decodeStream(url.openConnection().getInputStream());
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        return NO_TILE;
+                    }
 
                 } else {
-                  BitmapFactory.Options options = new BitmapFactory.Options();
-                  options.inPreferredConfig = Bitmap.Config.ARGB_8888;
-                  File dir = getContext().getFilesDir();
-                  File myFile = new File(dir + "/tiles", areaId + "/" + zoomCord + "x" + xCord + "x" + yCord + ".png");
+                    BitmapFactory.Options options = new BitmapFactory.Options();
+                    options.inPreferredConfig = Bitmap.Config.ARGB_8888;
+                    File dir = getContext().getFilesDir();
+                    File myFile = new File(dir + "/tiles", areaId + "/" + zoomCord + "x" + xCord + "x" + yCord + ".png");
 
-                  try {
-                      image = BitmapFactory.decodeFile(myFile.getAbsolutePath(), options);
-                  } catch (Exception e) {
-                      e.printStackTrace();
-                      return NO_TILE;
-                  }
+                    try {
+                        image = BitmapFactory.decodeFile(myFile.getAbsolutePath(), options);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        return NO_TILE;
+                    }
                 }
+                int zsteps = 1;
 
                 if (zoom > this.maxZoom) {
-                  int zsteps = zoom - this.maxZoom;
-                  int relation = (int) Math.pow(2, zsteps) ;
-                  int size = (int) (TILE_SIZE / relation);
-                  // we scale the map to keep the tiles sharp
-                  scaleSize = (int) (TILE_SIZE * 2);
-                  srcX = (int) size  * (x % relation);
-                  srcY = (int) size  * (y % relation);
-                  srcW = (int) size;
-                  srcH = (int) size;
+                    zsteps = zoom - this.maxZoom;
+                    int relation = (int) Math.pow(2, zsteps) ;
+                    int size = (int) (TILE_SIZE / relation);
+                    // we scale the map to keep the tiles sharp
+                    scaleSize = (int) (TILE_SIZE * 2);
+                    srcX = (int) size  * (x % relation);
+                    srcY = (int) size  * (y % relation);
+                    srcW = (int) size;
+                    srcH = (int) size;
                 }
 
                 if (image != null) {
@@ -154,46 +155,48 @@ public class AirMapCanvasInteractionUrlTile extends AirMapFeature {
                     double[] precision = coordinates.getPrecision();
                     int xFilter = (int)(precision[0] * width);
                     int yFilter = (int)(precision[1] * height);
+                    double THRESHOLD = zoom * 0.5 * zsteps;
 
                     for(int xPoint=0; xPoint < width; xPoint++) {
-                      for(int yPoint=0; yPoint < height; yPoint++) {
-                        c = scaledBitmap.getPixel(xPoint, yPoint);
+                        for(int yPoint=0; yPoint < height; yPoint++) {
+                            c = scaledBitmap.getPixel(xPoint, yPoint);
 
-                        red = Color.red(c);
-                        green = Color.green(c);
-                        blue = Color.blue(c);
+                            red = Color.red(c);
+                            green = Color.green(c);
+                            blue = Color.blue(c);
 
-                        if (red > 255)
-                            red = 255;
-                        if (green > 255)
-                            green = 255;
+                            if (red > 255)
+                                red = 255;
+                            if (green > 255)
+                                green = 255;
 
-                        int day = red * 255 + green;
-                        boolean inDay = day > 0 && day >= minDate && day <= maxDate;
-                        boolean inPoint = xPoint == xFilter && yPoint == yFilter;
+                            int day = red * 255 + green;
+                            boolean inDay = day > 0 && day >= minDate && day <= maxDate;
+                            boolean inXPoint = xPoint >= (xFilter - THRESHOLD) && (xPoint <= xFilter + THRESHOLD);
+                            boolean inYPoint = yPoint >= (yFilter - THRESHOLD) && (yPoint <= yFilter + THRESHOLD);
 
-                        if (inDay && inPoint) {
-                            red = 255;
-                            green = 255;
-                            blue = 255;
-                            alpha = 255;
-                        } else {
-                            alpha = 0;
+                            if (inDay && inXPoint && inYPoint) {
+                                red = 255;
+                                green = 255;
+                                blue = 255;
+                                alpha = 150;
+                            } else {
+                                alpha = 0;
+                            }
+
+                            finalBitmap.setPixel(xPoint, yPoint, Color.argb(alpha, red, green, blue));
                         }
-
-                        finalBitmap.setPixel(xPoint, yPoint, Color.argb(alpha, red, green, blue));
-                      }
                     }
 
-                  stream = new ByteArrayOutputStream();
-                  finalBitmap.compress(Bitmap.CompressFormat.PNG, 0, stream);
-                  bitmapData = stream.toByteArray();
-                  return new Tile(TILE_SIZE, TILE_SIZE, bitmapData);
+                    stream = new ByteArrayOutputStream();
+                    finalBitmap.compress(Bitmap.CompressFormat.PNG, 0, stream);
+                    bitmapData = stream.toByteArray();
+                    return new Tile(TILE_SIZE, TILE_SIZE, bitmapData);
                 } else {
-                  return NO_TILE;
+                    return NO_TILE;
                 }
             } else {
-              return NO_TILE;
+                return NO_TILE;
             }
         }
 
@@ -312,7 +315,7 @@ public class AirMapCanvasInteractionUrlTile extends AirMapFeature {
         options.zIndex(zIndex);
         this.tileProvider = new AIRMapCanvasInteractionUrlTileProvider(256, 256, this.urlTemplate, this.maxZoom, this.areaId, this.isConnected, this.minDate, this.maxDate, this.coordinates);
         options.tileProvider(this.tileProvider);
-        // options.fadeIn(false);
+        options.fadeIn(false);
         return options;
     }
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasInteractionUrlTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasInteractionUrlTile.java
@@ -2,335 +2,76 @@ package com.airbnb.android.react.maps;
 
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.Color;
-import android.net.Uri;
-import android.os.Environment;
-import android.util.Log;
-
-import com.google.android.gms.maps.GoogleMap;
-import com.google.android.gms.maps.model.Tile;
-import com.google.android.gms.maps.model.TileOverlay;
 import com.google.android.gms.maps.model.TileOverlayOptions;
-import com.google.android.gms.maps.model.TileProvider;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.net.URL;
-import java.lang.Math;
 
-public class AirMapCanvasInteractionUrlTile extends AirMapFeature {
-    private class Coordinates {
-        private int[] tile;
-        private double[] precision;
+public class AirMapCanvasInteractionUrlTile extends AirMapCanvasFeature {
 
-        public Coordinates(int[] tile, double[] precision) {
-            this.tile = tile;
-            this.precision = precision;
+    public AirMapCanvasInteractionUrlTile(Context context){ super(context); }
+
+    class AIRMapCanvasInteractionTileProvider extends AirMapCanvasTileProvider {
+
+        public AIRMapCanvasInteractionTileProvider(int width, int height, String urlTemplate, int maxZoom, String areaId, boolean isConnected, String minDate, String maxDate, String alertType, Coordinates coordinates)  {
+            super(width, height, urlTemplate, maxZoom, areaId, isConnected, minDate, maxDate, alertType, coordinates);
         }
 
-        public int[] getTile() {
-            return tile;
+        protected Context getParentContext() {
+            return getContext();
         }
-        public double[] getPrecision() {
-            return precision;
-        }
-    }
+
+        protected Bitmap paintTile(Bitmap scaledBitmap, int width, int height, int zoom, int zsteps, int minDate, int maxDate) {
+            Bitmap finalBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+            int red, green, blue, alpha, c;
+            double[] precision = coordinates.getPrecision();
+            int xFilter = (int)(precision[0] * width);
+            int yFilter = (int)(precision[1] * height);
+            double THRESHOLD = zoom * 0.5 * zsteps;
 
 
-    class AIRMapCanvasInteractionUrlTileProvider implements TileProvider {
-        private String urlTemplate;
-        private int width;
-        private int height;
-        private int maxZoom;
-        private String areaId;
-        private String minDate;
-        private String maxDate;
-        private boolean isConnected;
-        private Coordinates coordinates;
-        public AIRMapCanvasInteractionUrlTileProvider(int width, int height, String urlTemplate, int maxZoom, String areaId, boolean isConnected, String minDate, String maxDate, Coordinates coordinates) {
-            super();
-            this.width = width;
-            this.height = height;
-            this.urlTemplate = urlTemplate;
-            this.maxZoom = maxZoom;
-            this.areaId = areaId;
-            this.minDate = minDate;
-            this.maxDate = maxDate;
-            this.isConnected = isConnected;
-            this.coordinates = coordinates;
-        }
-        @Override
-        public Tile getTile(int x, int y, int zoom) {
-            int TILE_SIZE = this.width;
-            int maxZoom = 12;
-            int xCord = x;
-            int yCord = y;
-            int zoomCord = zoom;
-            int srcX = 0;
-            int srcY = 0;
-            int srcW = this.width;
-            int srcH = this.height;
-            int scaleSize = 1;
+            for(int xPoint=0; xPoint < width; xPoint++) {
+                for(int yPoint=0; yPoint < height; yPoint++) {
+                    c = scaledBitmap.getPixel(xPoint, yPoint);
 
-            int minDate = Integer.valueOf(this.minDate);
-            int maxDate = Integer.valueOf(this.maxDate);
+                    red = Color.red(c);
+                    green = Color.green(c);
+                    blue = Color.blue(c);
 
-            int[] tile = coordinates.getTile();
-            Log.d("tile Position: ", x + "-" + y + "-" + zoom);
-            Log.d("tile given: ", tile[0] + "-" + tile[1] + "-" + tile[2]);
+                    if (red > 255)
+                        red = 255;
+                    if (green > 255)
+                        green = 255;
 
-            if (tile[0] == x && tile[1] == y && tile[2] == zoom) {
+                    int day = red * 255 + green;
+                    boolean inDay = day > 0 && day >= minDate && day <= maxDate;
+                    boolean inXPoint = xPoint >= (xFilter - THRESHOLD) && (xPoint <= xFilter + THRESHOLD);
+                    boolean inYPoint = yPoint >= (yFilter - THRESHOLD) && (yPoint <= yFilter + THRESHOLD);
 
-                if (zoom > this.maxZoom) {
-                    xCord = (int)(x / (Math.pow(2, zoom - this.maxZoom)));
-                    yCord = (int)(y / (Math.pow(2, zoom - this.maxZoom)));
-                    zoomCord = this.maxZoom;
-                }
-
-                ByteArrayOutputStream stream = new ByteArrayOutputStream();
-                byte[] bitmapData = stream.toByteArray();
-
-                Bitmap image;
-
-                if (this.isConnected) {
-                    String providerUrl = this.urlTemplate
-                            .replace("{x}", Integer.toString(xCord))
-                            .replace("{y}", Integer.toString(yCord))
-                            .replace("{z}", Integer.toString(zoomCord));
-
-                    URL url;
-                    try {
-                        url = new URL(providerUrl);
-                        image = BitmapFactory.decodeStream(url.openConnection().getInputStream());
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                        return NO_TILE;
+                    if (inDay && inXPoint && inYPoint) {
+                        red = 255;
+                        green = 255;
+                        blue = 255;
+                        alpha = 150;
+                    } else {
+                        alpha = 0;
                     }
 
-                } else {
-                    BitmapFactory.Options options = new BitmapFactory.Options();
-                    options.inPreferredConfig = Bitmap.Config.ARGB_8888;
-                    File dir = getContext().getFilesDir();
-                    File myFile = new File(dir + "/tiles", areaId + "/" + zoomCord + "x" + xCord + "x" + yCord + ".png");
-
-                    try {
-                        image = BitmapFactory.decodeFile(myFile.getAbsolutePath(), options);
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                        return NO_TILE;
-                    }
+                    finalBitmap.setPixel(xPoint, yPoint, Color.argb(alpha, red, green, blue));
                 }
-                int zsteps = 1;
-
-                if (zoom > this.maxZoom) {
-                    zsteps = zoom - this.maxZoom;
-                    int relation = (int) Math.pow(2, zsteps) ;
-                    int size = (int) (TILE_SIZE / relation);
-                    // we scale the map to keep the tiles sharp
-                    scaleSize = (int) (TILE_SIZE * 2);
-                    srcX = (int) size  * (x % relation);
-                    srcY = (int) size  * (y % relation);
-                    srcW = (int) size;
-                    srcH = (int) size;
-                }
-
-                if (image != null) {
-                    Bitmap croppedBitmap = Bitmap.createBitmap(image , srcX , srcY, srcW, srcH);
-                    Bitmap scaledBitmap = croppedBitmap;
-                    if (zoom > maxZoom) {
-                        // The last false is for filter anti-aliasing
-                        scaledBitmap = Bitmap.createScaledBitmap (croppedBitmap, scaleSize, scaleSize, false);
-                    }
-
-                    int width, height, r, g, b, c;
-                    height = scaledBitmap.getHeight();
-                    width = scaledBitmap.getWidth();
-
-                    Bitmap finalBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
-                    int red, green, blue, pixel, alpha;
-                    int[] pixels = new int[width * height];
-                    scaledBitmap.getPixels(pixels, 0, width, 0, 0, width, height);
-
-                    double[] precision = coordinates.getPrecision();
-                    int xFilter = (int)(precision[0] * width);
-                    int yFilter = (int)(precision[1] * height);
-                    double THRESHOLD = zoom * 0.5 * zsteps;
-
-                    for(int xPoint=0; xPoint < width; xPoint++) {
-                        for(int yPoint=0; yPoint < height; yPoint++) {
-                            c = scaledBitmap.getPixel(xPoint, yPoint);
-
-                            red = Color.red(c);
-                            green = Color.green(c);
-                            blue = Color.blue(c);
-
-                            if (red > 255)
-                                red = 255;
-                            if (green > 255)
-                                green = 255;
-
-                            int day = red * 255 + green;
-                            boolean inDay = day > 0 && day >= minDate && day <= maxDate;
-                            boolean inXPoint = xPoint >= (xFilter - THRESHOLD) && (xPoint <= xFilter + THRESHOLD);
-                            boolean inYPoint = yPoint >= (yFilter - THRESHOLD) && (yPoint <= yFilter + THRESHOLD);
-
-                            if (inDay && inXPoint && inYPoint) {
-                                red = 255;
-                                green = 255;
-                                blue = 255;
-                                alpha = 150;
-                            } else {
-                                alpha = 0;
-                            }
-
-                            finalBitmap.setPixel(xPoint, yPoint, Color.argb(alpha, red, green, blue));
-                        }
-                    }
-
-                    stream = new ByteArrayOutputStream();
-                    finalBitmap.compress(Bitmap.CompressFormat.PNG, 0, stream);
-                    bitmapData = stream.toByteArray();
-                    return new Tile(TILE_SIZE, TILE_SIZE, bitmapData);
-                } else {
-                    return NO_TILE;
-                }
-            } else {
-                return NO_TILE;
             }
+            return finalBitmap;
         }
 
-        public void setUrlTemplate(String urlTemplate) {
-            this.urlTemplate = urlTemplate;
-        }
 
-        public void setMaxZoom(int maxZoom) {
-            this.maxZoom = maxZoom;
-        }
-
-        public void setAreaId(String areaId) {
-            this.areaId = areaId;
-        }
-
-        public void setIsConnected(boolean isConnected) {
-            this.isConnected = isConnected;
-        }
-
-        public void setCoordinates(Coordinates coordinates) {
-            this.coordinates = coordinates;
-        }
     }
 
-    private TileOverlayOptions tileOverlayOptions;
-    private TileOverlay tileOverlay;
-    private AIRMapCanvasInteractionUrlTileProvider tileProvider;
 
-    private String urlTemplate;
-    private int maxZoom;
-    private String areaId;
-    private String minDate;
-    private String maxDate;
-    private boolean isConnected;
-    private float zIndex;
-    private Coordinates coordinates;
-
-    public AirMapCanvasInteractionUrlTile(Context context) {
-        super(context);
-    }
-
-    public void setUrlTemplate(String urlTemplate) {
-        this.urlTemplate = urlTemplate;
-        if (tileProvider != null) {
-            tileProvider.setUrlTemplate(urlTemplate);
-        }
-        if (tileOverlay != null) {
-            tileOverlay.clearTileCache();
-        }
-    }
-
-    public void setMaxZoom(int maxZoom) {
-        this.maxZoom = maxZoom;
-        if (tileProvider != null) {
-            tileProvider.setMaxZoom(maxZoom);
-        }
-        if (tileOverlay != null) {
-            tileOverlay.clearTileCache();
-        }
-    }
-
-    public void setAreaId(String areaId) {
-        this.areaId = areaId;
-        if (tileProvider != null) {
-            tileProvider.setAreaId(areaId);
-        }
-        if (tileOverlay != null) {
-            tileOverlay.clearTileCache();
-        }
-    }
-
-    public void setIsConnected(boolean isConnected) {
-        this.isConnected = isConnected;
-        if (tileProvider != null) {
-            tileProvider.setIsConnected(isConnected);
-        }
-        if (tileOverlay != null) {
-            tileOverlay.clearTileCache();
-        }
-    }
-
-    public void setMinDate(String minDate) {
-        this.minDate = minDate;
-    }
-
-    public void setMaxDate(String maxDate) {
-        this.maxDate = maxDate;
-    }
-
-    public void setZIndex(float zIndex) {
-        this.zIndex = zIndex;
-        if (tileOverlay != null) {
-            tileOverlay.setZIndex(zIndex);
-        }
-    }
-
-    public void setCoordinates(int[] tile, double[] precision) {
-        this.coordinates = new Coordinates(tile, precision);
-        if (tileProvider != null) {
-            tileProvider.setCoordinates(coordinates);
-        }
-        if (tileOverlay != null) {
-            tileOverlay.clearTileCache();
-        }
-    }
-
-    public TileOverlayOptions getTileOverlayOptions() {
-        if (tileOverlayOptions == null) {
-            tileOverlayOptions = createTileOverlayOptions();
-        }
-        return tileOverlayOptions;
-    }
-
-    private TileOverlayOptions createTileOverlayOptions() {
+    protected TileOverlayOptions createTileOverlayOptions() {
         TileOverlayOptions options = new TileOverlayOptions();
         options.zIndex(zIndex);
-        this.tileProvider = new AIRMapCanvasInteractionUrlTileProvider(256, 256, this.urlTemplate, this.maxZoom, this.areaId, this.isConnected, this.minDate, this.maxDate, this.coordinates);
+        this.tileProvider = new AIRMapCanvasInteractionTileProvider(256, 256, this.urlTemplate, this.maxZoom, this.areaId,  this.isConnected, this.minDate, this.maxDate, this.alertType, this.coordinates);
         options.tileProvider(this.tileProvider);
-        options.fadeIn(false);
         return options;
     }
 
-    @Override
-    public Object getFeature() {
-        return tileOverlay;
-    }
-
-    @Override
-    public void addToMap(GoogleMap map) {
-        this.tileOverlay = map.addTileOverlay(getTileOverlayOptions());
-    }
-
-    @Override
-    public void removeFromMap(GoogleMap map) {
-        tileOverlay.remove();
-    }
 }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasInteractionUrlTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasInteractionUrlTile.java
@@ -1,0 +1,315 @@
+package com.airbnb.android.react.maps;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Color;
+import android.net.Uri;
+import android.os.Environment;
+import android.util.Log;
+
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.Tile;
+import com.google.android.gms.maps.model.TileOverlay;
+import com.google.android.gms.maps.model.TileOverlayOptions;
+import com.google.android.gms.maps.model.TileProvider;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.net.URL;
+import java.lang.Math;
+
+public class AirMapCanvasInteractionUrlTile extends AirMapFeature {
+    private class Coordinates {
+        private double lat;
+        private double lng;
+        private int[] tile;
+
+        public Coordinates(double lat, double lng, int[] tile) {
+            this.lat = lat;
+            this.lng = lng;
+            this.tile = tile;
+        }
+
+        public double getLat() {
+            return lat;
+        }
+
+        public double getLng() {
+            return lng;
+        }
+
+        public int[] getTile() {
+            return tile;
+        }
+    }
+
+
+    class AIRMapCanvasInteractionUrlTileProvider implements TileProvider {
+        private String urlTemplate;
+        private int width;
+        private int height;
+        private int maxZoom;
+        private String areaId;
+        private boolean isConnected;
+        private Coordinates coordinates;
+        public AIRMapCanvasInteractionUrlTileProvider(int width, int height, String urlTemplate, int maxZoom, String areaId, boolean isConnected, Coordinates coordinates) {
+            super();
+            this.width = width;
+            this.height = height;
+            this.urlTemplate = urlTemplate;
+            this.maxZoom = maxZoom;
+            this.areaId = areaId;
+            this.isConnected = isConnected;
+            this.coordinates = coordinates;
+        }
+        @Override
+        public Tile getTile(int x, int y, int zoom) {
+            int TILE_SIZE = this.width;
+            int maxZoom = 12;
+            int xCord = x;
+            int yCord = y;
+            int zoomCord = zoom;
+            int srcX = 0;
+            int srcY = 0;
+            int srcW = this.width;
+            int srcH = this.height;
+            int scaleSize = 1;
+
+            int[] tile = coordinates.getTile();
+            Log.d("tile Position: ", x + "-" + y + "-" + zoom);
+            Log.d("tile given: ", tile[0] + "-" + tile[1] + "-" + tile[2]);
+
+            if (tile[0] == x && tile[1] == y && tile[2] == zoom) {
+
+                if (zoom > this.maxZoom) {
+                    xCord = (int)(x / (Math.pow(2, zoom - this.maxZoom)));
+                    yCord = (int)(y / (Math.pow(2, zoom - this.maxZoom)));
+                    zoomCord = this.maxZoom;
+                }
+
+                ByteArrayOutputStream stream = new ByteArrayOutputStream();
+                byte[] bitmapData = stream.toByteArray();
+
+                Bitmap image;
+
+                if (this.isConnected) {
+                    String providerUrl = this.urlTemplate
+                      .replace("{x}", Integer.toString(xCord))
+                      .replace("{y}", Integer.toString(yCord))
+                      .replace("{z}", Integer.toString(zoomCord));
+
+                    URL url;
+                    try {
+                        url = new URL(providerUrl);
+                        image = BitmapFactory.decodeStream(url.openConnection().getInputStream());
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        return NO_TILE;
+                    }
+
+                } else {
+                    BitmapFactory.Options options = new BitmapFactory.Options();
+                    options.inPreferredConfig = Bitmap.Config.ARGB_8888;
+                    File dir = getContext().getFilesDir();
+                    File myFile = new File(dir + "/tiles", areaId + "/" + zoomCord + "x" + xCord + "x" + yCord + ".png");
+
+                    try {
+                        image = BitmapFactory.decodeFile(myFile.getAbsolutePath(), options);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        return NO_TILE;
+                    }
+                }
+
+                if (zoom > this.maxZoom) {
+                    int zsteps = zoom - this.maxZoom;
+                    int relation = (int) Math.pow(2, zsteps) ;
+                    int size = (int) (TILE_SIZE / relation);
+                    // we scale the map to keep the tiles sharp
+                    scaleSize = (int) (TILE_SIZE * 2);
+                    srcX = (int) size  * (x % relation);
+                    srcY = (int) size  * (y % relation);
+                    srcW = (int) size;
+                    srcH = (int) size;
+                }
+
+                if (image != null) {
+                    Bitmap croppedBitmap = Bitmap.createBitmap(image , srcX , srcY, srcW, srcH);
+                    Bitmap scaledBitmap = croppedBitmap;
+                    if (zoom > maxZoom) {
+                        // The last false is for filter anti-aliasing
+                        scaledBitmap = Bitmap.createScaledBitmap (croppedBitmap, scaleSize, scaleSize, false);
+                    }
+
+                    int width, height, r, g, b, c;
+                    height = scaledBitmap.getHeight();
+                    width = scaledBitmap.getWidth();
+
+                    Bitmap finalBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+                    int red, green, blue, pixel, alpha;
+                    int[] pixels = new int[width * height];
+                    scaledBitmap.getPixels(pixels, 0, width, 0, 0, width, height);
+                    for (int i = 0; i < pixels.length; i++) {
+                        pixel = pixels[i];
+
+                        red = (pixel >> 16) & 0xFF;
+                        green = (pixel >> 8) & 0xFF;
+                        blue = pixel & 0xFF;
+
+                        int day = red * 255 + green;
+
+                        red = 255;
+                        green = 255;
+                        blue = 255;
+                        alpha = 100;
+
+                        pixels[i] = Color.argb(alpha, red, green, blue);
+                    }
+                    finalBitmap.setPixels(pixels, 0, width, 0, 0, width, height);
+
+                    stream = new ByteArrayOutputStream();
+                    finalBitmap.compress(Bitmap.CompressFormat.PNG, 0, stream);
+                    bitmapData = stream.toByteArray();
+                    return new Tile(TILE_SIZE, TILE_SIZE, bitmapData);
+                } else {
+                    return NO_TILE;
+                }
+            } else {
+              return NO_TILE;
+            }
+        }
+
+        public void setUrlTemplate(String urlTemplate) {
+            this.urlTemplate = urlTemplate;
+        }
+
+        public void setMaxZoom(int maxZoom) {
+            this.maxZoom = maxZoom;
+        }
+
+        public void setAreaId(String areaId) {
+            this.areaId = areaId;
+        }
+
+        public void setIsConnected(boolean isConnected) {
+            this.isConnected = isConnected;
+        }
+
+        public void setCoordinates(Coordinates coordinates) {
+            this.coordinates = coordinates;
+        }
+    }
+
+    private TileOverlayOptions tileOverlayOptions;
+    private TileOverlay tileOverlay;
+    private AIRMapCanvasInteractionUrlTileProvider tileProvider;
+
+    private String urlTemplate;
+    private int maxZoom;
+    private String areaId;
+    private String minDate;
+    private String maxDate;
+    private boolean isConnected;
+    private float zIndex;
+    private Coordinates coordinates;
+
+    public AirMapCanvasInteractionUrlTile(Context context) {
+        super(context);
+    }
+
+    public void setUrlTemplate(String urlTemplate) {
+        this.urlTemplate = urlTemplate;
+        if (tileProvider != null) {
+            tileProvider.setUrlTemplate(urlTemplate);
+        }
+        if (tileOverlay != null) {
+            tileOverlay.clearTileCache();
+        }
+    }
+
+    public void setMaxZoom(int maxZoom) {
+        this.maxZoom = maxZoom;
+        if (tileProvider != null) {
+            tileProvider.setMaxZoom(maxZoom);
+        }
+        if (tileOverlay != null) {
+            tileOverlay.clearTileCache();
+        }
+    }
+
+    public void setAreaId(String areaId) {
+        this.areaId = areaId;
+        if (tileProvider != null) {
+            tileProvider.setAreaId(areaId);
+        }
+        if (tileOverlay != null) {
+            tileOverlay.clearTileCache();
+        }
+    }
+
+    public void setIsConnected(boolean isConnected) {
+        this.isConnected = isConnected;
+        if (tileProvider != null) {
+            tileProvider.setIsConnected(isConnected);
+        }
+        if (tileOverlay != null) {
+            tileOverlay.clearTileCache();
+        }
+    }
+
+    public void setMinDate(String minDate) {
+        this.minDate = minDate;
+    }
+
+    public void setMaxDate(String maxDate) {
+        this.minDate = maxDate;
+    }
+
+    public void setZIndex(float zIndex) {
+        this.zIndex = zIndex;
+        if (tileOverlay != null) {
+            tileOverlay.setZIndex(zIndex);
+        }
+    }
+
+    public void setCoordinates(double lat, double lng, int[] tile) {
+        this.coordinates = new Coordinates(lat, lng, tile);
+        if (tileProvider != null) {
+            tileProvider.setCoordinates(coordinates);
+        }
+        if (tileOverlay != null) {
+            tileOverlay.clearTileCache();
+        }
+    }
+
+    public TileOverlayOptions getTileOverlayOptions() {
+        if (tileOverlayOptions == null) {
+            tileOverlayOptions = createTileOverlayOptions();
+        }
+        return tileOverlayOptions;
+    }
+
+    private TileOverlayOptions createTileOverlayOptions() {
+        TileOverlayOptions options = new TileOverlayOptions();
+        options.zIndex(zIndex);
+        this.tileProvider = new AIRMapCanvasInteractionUrlTileProvider(256, 256, this.urlTemplate, this.maxZoom, this.areaId, this.isConnected, this.coordinates);
+        options.tileProvider(this.tileProvider);
+        return options;
+    }
+
+    @Override
+    public Object getFeature() {
+        return tileOverlay;
+    }
+
+    @Override
+    public void addToMap(GoogleMap map) {
+        this.tileOverlay = map.addTileOverlay(getTileOverlayOptions());
+    }
+
+    @Override
+    public void removeFromMap(GoogleMap map) {
+        tileOverlay.remove();
+    }
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasInteractionUrlTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasInteractionUrlTile.java
@@ -37,12 +37,17 @@ public class AirMapCanvasInteractionUrlTile extends AirMapCanvasFeature {
                     green = Color.green(c);
                     blue = Color.blue(c);
 
-                    if (red > 255)
-                        red = 255;
-                    if (green > 255)
-                        green = 255;
+                    if (red > 255) red = 255;
+                    if (green > 255) green = 255;
+                    if (blue > 255) blue = 255;
 
-                    int day = red * 255 + green;
+                    int day;
+                    if (this.alertType != null && this.alertType.equals("viirs")) {
+                        day = blue;
+                    } else {
+                        day = red * 255 + green;
+                    }
+
                     boolean inDay = day > 0 && day >= minDate && day <= maxDate;
                     boolean inXPoint = xPoint >= (xFilter - THRESHOLD) && (xPoint <= xFilter + THRESHOLD);
                     boolean inYPoint = yPoint >= (yFilter - THRESHOLD) && (yPoint <= yFilter + THRESHOLD);

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasInteractionUrlTileManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasInteractionUrlTileManager.java
@@ -78,7 +78,7 @@ public class AirMapCanvasInteractionUrlTileManager extends ViewGroupManager<AirM
         if (coordinates != null) {
             int[] tile = new int[]{coordinates.getArray("tile").getInt(0), coordinates.getArray("tile").getInt(1), coordinates.getArray("tile").getInt(2)};
             double[] precision = new double[]{coordinates.getArray("precision").getDouble(0), coordinates.getArray("precision").getDouble(1)};
-            view.setCoordinates(tile, precision);
+            view.setCoordinates(new Coordinates(tile, precision));
         }
     }
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasInteractionUrlTileManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasInteractionUrlTileManager.java
@@ -29,7 +29,6 @@ public class AirMapCanvasInteractionUrlTileManager extends ViewGroupManager<AirM
 
     @Override
     public String getName() {
-        Log.d("Map", "Get name");
         return "AIRMapCanvasInteractionUrlTile";
     }
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasInteractionUrlTileManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasInteractionUrlTileManager.java
@@ -77,7 +77,8 @@ public class AirMapCanvasInteractionUrlTileManager extends ViewGroupManager<AirM
     public void setCoordinates(AirMapCanvasInteractionUrlTile view, ReadableMap coordinates) {
         if (coordinates != null) {
             int[] tile = new int[]{coordinates.getArray("tile").getInt(0), coordinates.getArray("tile").getInt(1), coordinates.getArray("tile").getInt(2)};
-            view.setCoordinates(coordinates.getDouble("latitude"), coordinates.getDouble("longitude"), tile);
+            double[] precision = new double[]{coordinates.getArray("precision").getDouble(0), coordinates.getArray("precision").getDouble(1)};
+            view.setCoordinates(tile, precision);
         }
     }
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasInteractionUrlTileManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasInteractionUrlTileManager.java
@@ -1,0 +1,84 @@
+package com.airbnb.android.react.maps;
+
+import android.content.Context;
+import android.os.Build;
+import android.util.DisplayMetrics;
+import android.util.Log;
+import android.view.WindowManager;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
+
+public class AirMapCanvasInteractionUrlTileManager extends ViewGroupManager<AirMapCanvasInteractionUrlTile> {
+    private DisplayMetrics metrics;
+
+    public AirMapCanvasInteractionUrlTileManager(ReactApplicationContext reactContext) {
+        super();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            metrics = new DisplayMetrics();
+            ((WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE))
+                    .getDefaultDisplay()
+                    .getRealMetrics(metrics);
+        } else {
+            metrics = reactContext.getResources().getDisplayMetrics();
+        }
+    }
+
+    @Override
+    public String getName() {
+        Log.d("Map", "Get name");
+        return "AIRMapCanvasInteractionUrlTile";
+    }
+
+    @Override
+    public AirMapCanvasInteractionUrlTile createViewInstance(ThemedReactContext context) {
+        return new AirMapCanvasInteractionUrlTile(context);
+    }
+
+    @ReactProp(name = "urlTemplate")
+    public void setUrlTemplate(AirMapCanvasInteractionUrlTile view, String urlTemplate) {
+        view.setUrlTemplate(urlTemplate);
+    }
+
+    @ReactProp(name = "maxZoom", defaultInt = 12)
+    public void setMaxZoom(AirMapCanvasInteractionUrlTile view, int maxZoom) {
+        view.setMaxZoom(maxZoom);
+    }
+
+    @ReactProp(name = "areaId")
+    public void setAreaId(AirMapCanvasInteractionUrlTile view, String areaId) {
+        view.setAreaId(areaId);
+    }
+
+    @ReactProp(name = "isConnected", defaultBoolean = true)
+    public void setIsConnected(AirMapCanvasInteractionUrlTile view, boolean isConnected) {
+        view.setIsConnected(isConnected);
+    }
+
+    @ReactProp(name = "minDate")
+    public void setMinDate(AirMapCanvasInteractionUrlTile view, String minDate) {
+        view.setMinDate(minDate);
+    }
+
+    @ReactProp(name = "maxDate")
+    public void setMaxDate(AirMapCanvasInteractionUrlTile view, String maxDate) {
+        view.setMaxDate(maxDate);
+    }
+
+    @ReactProp(name = "zIndex", defaultFloat = -1.0f)
+    public void setZIndex(AirMapCanvasInteractionUrlTile view, float zIndex) {
+        view.setZIndex(zIndex);
+    }
+
+    @ReactProp(name = "coordinates")
+    public void setCoordinates(AirMapCanvasInteractionUrlTile view, ReadableMap coordinates) {
+        if (coordinates != null) {
+            int[] tile = new int[]{coordinates.getArray("tile").getInt(0), coordinates.getArray("tile").getInt(1), coordinates.getArray("tile").getInt(2)};
+            view.setCoordinates(coordinates.getDouble("latitude"), coordinates.getDouble("longitude"), tile);
+        }
+    }
+
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasTileProvider.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasTileProvider.java
@@ -1,0 +1,182 @@
+package com.airbnb.android.react.maps;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Color;
+import android.util.Log;
+
+import com.google.android.gms.maps.model.Tile;
+import com.google.android.gms.maps.model.TileProvider;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.net.URL;
+
+/**
+ * Created by joseangel.parreno@vizzuality.com on 19/05/2017.
+ */
+
+
+public abstract class AirMapCanvasTileProvider implements TileProvider {
+    protected String urlTemplate;
+    protected int width;
+    protected int height;
+    protected int maxZoom;
+    protected String areaId;
+    protected String minDate;
+    protected String maxDate;
+    protected boolean isConnected;
+    protected Coordinates coordinates;
+    protected String alertType;
+
+    public AirMapCanvasTileProvider(int width, int height, String urlTemplate, int maxZoom, String areaId, boolean isConnected, String minDate, String maxDate, String alertType, Coordinates coordinates) {
+        super();
+        this.width = width;
+        this.height = height;
+        this.urlTemplate = urlTemplate;
+        this.maxZoom = maxZoom;
+        this.areaId = areaId;
+        this.minDate = minDate;
+        this.maxDate = maxDate;
+        this.alertType = alertType;
+        this.isConnected = isConnected;
+        this.coordinates = coordinates;
+    }
+    @Override
+    public Tile getTile(int x, int y, int zoom) {
+        int TILE_SIZE = this.width;
+        int maxZoom = 12;
+        int xCord = x;
+        int yCord = y;
+        int zoomCord = zoom;
+        int srcX = 0;
+        int srcY = 0;
+        int srcW = this.width;
+        int srcH = this.height;
+        int scaleSize = 1;
+
+        int minDate = Integer.valueOf(this.minDate);
+        int maxDate = Integer.valueOf(this.maxDate);
+
+        if (this.coordinates != null) {
+            int[] tile = this.coordinates.getTile();
+            Log.d("tile Position: ", x + "-" + y + "-" + zoom);
+            Log.d("tile given: ", tile[0] + "-" + tile[1] + "-" + tile[2]);
+            if(!(tile[0] == x && tile[1] == y && tile[2] == zoom)) {
+                return NO_TILE;
+            }
+        }
+
+        if (zoom > this.maxZoom) {
+            xCord = (int)(x / (Math.pow(2, zoom - this.maxZoom)));
+            yCord = (int)(y / (Math.pow(2, zoom - this.maxZoom)));
+            zoomCord = this.maxZoom;
+        }
+
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        byte[] bitmapData = stream.toByteArray();
+
+        Bitmap image;
+
+        if (this.isConnected) {
+            String providerUrl = this.urlTemplate
+                    .replace("{x}", Integer.toString(xCord))
+                    .replace("{y}", Integer.toString(yCord))
+                    .replace("{z}", Integer.toString(zoomCord));
+
+            URL url;
+            try {
+                url = new URL(providerUrl);
+                image = BitmapFactory.decodeStream(url.openConnection().getInputStream());
+            } catch (Exception e) {
+                e.printStackTrace();
+                return NO_TILE;
+            }
+
+        } else {
+            BitmapFactory.Options options = new BitmapFactory.Options();
+            options.inPreferredConfig = Bitmap.Config.ARGB_8888;
+            File dir = getParentContext().getFilesDir();
+            File myFile = new File(dir + "/tiles", areaId + "/" + zoomCord + "x" + xCord + "x" + yCord + ".png");
+
+            try {
+                image = BitmapFactory.decodeFile(myFile.getAbsolutePath(), options);
+            } catch (Exception e) {
+                e.printStackTrace();
+                return NO_TILE;
+            }
+        }
+        int zsteps = 1;
+
+        if (zoom > this.maxZoom) {
+            zsteps = zoom - this.maxZoom;
+            int relation = (int) Math.pow(2, zsteps) ;
+            int size = (int) (TILE_SIZE / relation);
+            // we scale the map to keep the tiles sharp
+            scaleSize = (int) (TILE_SIZE * 2);
+            srcX = (int) size  * (x % relation);
+            srcY = (int) size  * (y % relation);
+            srcW = (int) size;
+            srcH = (int) size;
+        }
+
+        if (image != null) {
+            Bitmap croppedBitmap = Bitmap.createBitmap(image , srcX , srcY, srcW, srcH);
+            Bitmap scaledBitmap = croppedBitmap;
+            if (zoom > maxZoom) {
+                // The last false is for filter anti-aliasing
+                scaledBitmap = Bitmap.createScaledBitmap (croppedBitmap, scaleSize, scaleSize, false);
+            }
+
+            int width, height;
+            height = scaledBitmap.getHeight();
+            width = scaledBitmap.getWidth();
+
+            //
+
+            int[] pixels = new int[width * height];
+            scaledBitmap.getPixels(pixels, 0, width, 0, 0, width, height);
+
+
+            Bitmap finalBitmap = paintTile(scaledBitmap, width, height, zoom, zsteps, minDate, maxDate);
+
+
+
+            stream = new ByteArrayOutputStream();
+            finalBitmap.compress(Bitmap.CompressFormat.PNG, 0, stream);
+            bitmapData = stream.toByteArray();
+            return new Tile(TILE_SIZE, TILE_SIZE, bitmapData);
+        } else {
+            return NO_TILE;
+        }
+    }
+
+    protected abstract Context getParentContext();
+
+    protected abstract Bitmap paintTile(Bitmap scaledBitmap, int width, int height, int zoom, int zsteps, int minDate, int maxDate);
+
+    public void setUrlTemplate(String urlTemplate) {
+        this.urlTemplate = urlTemplate;
+    }
+
+    public void setMaxZoom(int maxZoom) {
+        this.maxZoom = maxZoom;
+    }
+
+    public void setAreaId(String areaId) {
+        this.areaId = areaId;
+    }
+
+    public void setAlertType(String alertType) {
+        this.alertType = alertType;
+    }
+
+    public void setIsConnected(boolean isConnected) {
+        this.isConnected = isConnected;
+    }
+
+    public void setCoordinates(Coordinates coordinates) {
+        this.coordinates = coordinates;
+    }
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasTileProvider.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasTileProvider.java
@@ -61,8 +61,6 @@ public abstract class AirMapCanvasTileProvider implements TileProvider {
 
         if (this.coordinates != null) {
             int[] tile = this.coordinates.getTile();
-            Log.d("tile Position: ", x + "-" + y + "-" + zoom);
-            Log.d("tile given: ", tile[0] + "-" + tile[1] + "-" + tile[2]);
             if(!(tile[0] == x && tile[1] == y && tile[2] == zoom)) {
                 return NO_TILE;
             }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTile.java
@@ -3,6 +3,7 @@ package com.airbnb.android.react.maps;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.Color;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.util.Log;
@@ -60,33 +61,39 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
                 height = image.getHeight();
                 width = image.getWidth();
 
-                Bitmap bmpSephia = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
-                /*Canvas canvas = new Canvas(bmpSephia);
-                Paint paint = new Paint();
-                paint.setAntiAlias(true);
+                Bitmap intermediateBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+                int red, green, blue, pixel, alpha;
+                int[] pixels = new int[width * height];
+                image.getPixels(pixels, 0, width, 0, 0, width, height);
+                for (int i = 0; i < pixels.length; i++) {
+                    pixel = pixels[i];
 
-                canvas.drawBitmap(image, 0, 0, paint);*/
-                /*
-                for(int e=0; e < width; e++) {
-                    for(int f=0; f < height; f++) {
-                        c = image.getPixel(e, f);
-                        int day = Color.red(c) * 255 + Color.green(c);
+                    red = (pixel >> 16) & 0xFF;
+                    green = (pixel >> 8) & 0xFF;
+                    blue = pixel & 0xFF;
 
-                        if (day > 0 ) {
-                            r = 220;
-                            g = 102;
-                            b = 153;
+                    int day = red * 255 + green;
 
-                            bmpSephia.setPixel(e, f, Color.rgb(r, g, b));
-                        } else {
-                            bmpSephia.setPixel(e, f, Color.argb(0, 0, 0 ,0));
-                        }
+                    if (red > 255)
+                        red = 255;
+                    if (green > 255)
+                        green = 255;
+
+                    if (day > 0) {
+                        red = 220;
+                        green = 102;
+                        blue = 153;
+                        alpha = 255;
+                    } else {
+                        alpha = 0;
                     }
-                }*/
-
-
+                        
+                    pixels[i] = Color.argb(alpha, red, green, blue);
+                }
+                intermediateBitmap.setPixels(pixels, 0, width, 0, 0, width, height);        
+                
                 stream = new ByteArrayOutputStream();
-                image.compress(Bitmap.CompressFormat.PNG, 0, stream);
+                intermediateBitmap.compress(Bitmap.CompressFormat.PNG, 0, stream);
                 bitmapData = stream.toByteArray();
             } catch (MalformedURLException e) {
                 e.printStackTrace();

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTile.java
@@ -91,12 +91,14 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
                 BitmapFactory.Options options = new BitmapFactory.Options();
                 options.inPreferredConfig = Bitmap.Config.ARGB_8888;
                 File dir = getContext().getFilesDir();
-                File myFile = new File(dir + "/tiles", areaId + "/" + this.alertType + "/" + zoomCord + "x" + xCord + "x" + yCord + ".png");
+                File myFile = new File(dir + "/tiles" + "/" + this.alertType, areaId + "/" + zoomCord + "x" + xCord + "x" + yCord + ".png");
 
                 try {
                     image = BitmapFactory.decodeFile(myFile.getAbsolutePath(), options);
                 } catch (Exception e) {
                     e.printStackTrace();
+
+
                     return NO_TILE;
                 }
             }
@@ -141,20 +143,27 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
                     if (green > 255)
                         green = 255;
 
-                    int day = red * 255 + green;
+                    int day;
+                    if (this.alertType.equals("viirs")) {
+                        day = blue;
+                    } else {
+                        day = red * 255 + green;
+                    }
 
-                    if (day > 0 && day >= minDate && day <= maxDate) {
-                        if (this.alertType.equals("viirs")) {
+                    if(this.alertType.equals("viirs")) {
+                        if (day > 0) {
                             red = 244;
                             green = 66;
                             blue = 66;
                             alpha = 255;
                         } else {
-                            red = 220;
-                            green = 102;
-                            blue = 153;
-                            alpha = 255;
+                            alpha = 0;
                         }
+                    } else if (day > 0 && day >= minDate && day <= maxDate) {
+                        red = 220;
+                        green = 102;
+                        blue = 153;
+                        alpha = 255;
                     } else {
                         alpha = 0;
                     }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTile.java
@@ -27,15 +27,15 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
         private int width;
         private int height;
         private int maxZoom;
-        private String areaName;
+        private String areaId;
         private boolean isConnected;
-        public AIRMapCanvasUrlTileProvider(int width, int height, String urlTemplate, int maxZoom, String areaName, boolean isConnected) {
+        public AIRMapCanvasUrlTileProvider(int width, int height, String urlTemplate, int maxZoom, String areaId, boolean isConnected) {
             super();
             this.width = width;
             this.height = height;
             this.urlTemplate = urlTemplate;
             this.maxZoom = maxZoom;
-            this.areaName = areaName;
+            this.areaId = areaId;
             this.isConnected = isConnected;
         }
         @Override
@@ -50,6 +50,8 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
             int srcW = this.width;
             int srcH = this.height;
             int scaleSize = 1;
+
+            // Log.d("Position", String.valueOf(x) + "x" + String.valueOf(y) +  "x" + String.valueOf(zoom));
 
             if (zoom > this.maxZoom) {
                 xCord = (int)(x / (Math.pow(2, zoom - this.maxZoom)));
@@ -81,8 +83,8 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
             } else {
                 BitmapFactory.Options options = new BitmapFactory.Options();
                 options.inPreferredConfig = Bitmap.Config.ARGB_8888;
-                File dir = Environment.getExternalStorageDirectory();
-                File myFile = new File(dir, areaName + "/" + zoomCord + "x" + xCord + "x" + yCord + ".png");
+                File dir = getContext().getFilesDir();
+                File myFile = new File(dir, "tiles/" + areaId + "/" + zoomCord + "x" + xCord + "x" + yCord + ".png");
 
                 try {
                     image = BitmapFactory.decodeFile(myFile.getAbsolutePath(), options);
@@ -164,8 +166,8 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
             this.maxZoom = maxZoom;
         }
 
-        public void setAreaName(String areaName) {
-            this.areaName = areaName;
+        public void setAreaId(String areaId) {
+            this.areaId = areaId;
         }
 
         public void setIsConnected(boolean isConnected) {
@@ -179,7 +181,7 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
 
     private String urlTemplate;
     private int maxZoom;
-    private String areaName;
+    private String areaId;
     private String minDate;
     private String maxDate;
     private boolean isConnected;
@@ -209,10 +211,10 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
         }
     }
 
-    public void setAreaName(String areaName) {
-        this.areaName = areaName;
+    public void setAreaId(String areaId) {
+        this.areaId = areaId;
         if (tileProvider != null) {
-            tileProvider.setAreaName(areaName);
+            tileProvider.setAreaId(areaId);
         }
         if (tileOverlay != null) {
             tileOverlay.clearTileCache();
@@ -254,7 +256,7 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
     private TileOverlayOptions createTileOverlayOptions() {
         TileOverlayOptions options = new TileOverlayOptions();
         options.zIndex(zIndex);
-        this.tileProvider = new AIRMapCanvasUrlTileProvider(256, 256, this.urlTemplate, this.maxZoom, this.areaName, this.isConnected);
+        this.tileProvider = new AIRMapCanvasUrlTileProvider(256, 256, this.urlTemplate, this.maxZoom, this.areaId, this.isConnected);
         options.tileProvider(this.tileProvider);
         return options;
     }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTile.java
@@ -28,8 +28,10 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
         private int height;
         private int maxZoom;
         private String areaId;
+        private String minDate;
+        private String maxDate;
         private boolean isConnected;
-        public AIRMapCanvasUrlTileProvider(int width, int height, String urlTemplate, int maxZoom, String areaId, boolean isConnected) {
+        public AIRMapCanvasUrlTileProvider(int width, int height, String urlTemplate, int maxZoom, String areaId, boolean isConnected, String minDate, String maxDate) {
             super();
             this.width = width;
             this.height = height;
@@ -37,6 +39,8 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
             this.maxZoom = maxZoom;
             this.areaId = areaId;
             this.isConnected = isConnected;
+            this.minDate = minDate;
+            this.maxDate = maxDate;
         }
         @Override
         public Tile getTile(int x, int y, int zoom) {
@@ -50,7 +54,8 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
             int srcW = this.width;
             int srcH = this.height;
             int scaleSize = 1;
-
+            int minDate = Integer.valueOf(this.minDate);
+            int maxDate = Integer.valueOf(this.maxDate);
             // Log.d("Position", String.valueOf(x) + "x" + String.valueOf(y) +  "x" + String.valueOf(zoom));
 
             if (zoom > this.maxZoom) {
@@ -129,14 +134,14 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
                     green = (pixel >> 8) & 0xFF;
                     blue = pixel & 0xFF;
 
-                    int day = red * 255 + green;
-
                     if (red > 255)
                         red = 255;
                     if (green > 255)
                         green = 255;
 
-                    if (day > 0) {
+                    int day = red * 255 + green;
+
+                    if (day > 0 && day >= minDate && day <= maxDate) {
                         red = 220;
                         green = 102;
                         blue = 153;
@@ -236,7 +241,7 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
     }
 
     public void setMaxDate(String maxDate) {
-        this.minDate = maxDate;
+        this.maxDate = maxDate;
     }
 
     public void setZIndex(float zIndex) {
@@ -256,7 +261,7 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
     private TileOverlayOptions createTileOverlayOptions() {
         TileOverlayOptions options = new TileOverlayOptions();
         options.zIndex(zIndex);
-        this.tileProvider = new AIRMapCanvasUrlTileProvider(256, 256, this.urlTemplate, this.maxZoom, this.areaId, this.isConnected);
+        this.tileProvider = new AIRMapCanvasUrlTileProvider(256, 256, this.urlTemplate, this.maxZoom, this.areaId, this.isConnected, this.minDate, this.maxDate);
         options.tileProvider(this.tileProvider);
         return options;
     }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTile.java
@@ -2,315 +2,82 @@ package com.airbnb.android.react.maps;
 
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.Color;
-import android.net.Uri;
-import android.os.Environment;
-import android.util.Log;
-
-import com.google.android.gms.maps.GoogleMap;
-import com.google.android.gms.maps.model.Tile;
-import com.google.android.gms.maps.model.TileOverlay;
 import com.google.android.gms.maps.model.TileOverlayOptions;
-import com.google.android.gms.maps.model.TileProvider;
-
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.net.URL;
-import java.lang.Math;
 
 
-public class AirMapCanvasUrlTile extends AirMapFeature {
+public class AirMapCanvasUrlTile extends AirMapCanvasFeature {
 
-    class AIRMapCanvasUrlTileProvider implements TileProvider {
-        private String urlTemplate;
-        private int width;
-        private int height;
-        private int maxZoom;
-        private String areaId;
-        private String alertType;
-        private String minDate;
-        private String maxDate;
-        private boolean isConnected;
-        public AIRMapCanvasUrlTileProvider(int width, int height, String urlTemplate, int maxZoom, String areaId, String alertType, boolean isConnected, String minDate, String maxDate) {
-            super();
-            this.width = width;
-            this.height = height;
-            this.urlTemplate = urlTemplate;
-            this.maxZoom = maxZoom;
-            this.areaId = areaId;
-            this.alertType = alertType;
-            this.isConnected = isConnected;
-            this.minDate = minDate;
-            this.maxDate = maxDate;
+    public AirMapCanvasUrlTile(Context context){ super(context); }
+
+    class AIRMapCanvasUrlTileProvider extends AirMapCanvasTileProvider {
+
+        public AIRMapCanvasUrlTileProvider(int width, int height, String urlTemplate, int maxZoom, String areaId, boolean isConnected, String minDate, String maxDate, String alertType, Coordinates coordinates)  {
+            super(width, height, urlTemplate, maxZoom, areaId, isConnected, minDate, maxDate, alertType, coordinates);
         }
-        @Override
-        public Tile getTile(int x, int y, int zoom) {
-            int TILE_SIZE = this.width;
-            int maxZoom = 12;
-            int xCord = x;
-            int yCord = y;
-            int zoomCord = zoom;
-            int srcX = 0;
-            int srcY = 0;
-            int srcW = this.width;
-            int srcH = this.height;
-            int scaleSize = 1;
-            int minDate = Integer.valueOf(this.minDate);
-            int maxDate = Integer.valueOf(this.maxDate);
-            // Log.d("Position", String.valueOf(x) + "x" + String.valueOf(y) +  "x" + String.valueOf(zoom));
 
-            if (zoom > this.maxZoom) {
-                xCord = (int)(x / (Math.pow(2, zoom - this.maxZoom)));
-                yCord = (int)(y / (Math.pow(2, zoom - this.maxZoom)));
-                zoomCord = this.maxZoom;
-            }
+        protected Context getParentContext() {
+            return getContext();
+        }
 
-            ByteArrayOutputStream stream = new ByteArrayOutputStream();
-            byte[] bitmapData = stream.toByteArray();
-            Uri.Builder builder = new Uri.Builder();
+        protected Bitmap paintTile(Bitmap scaledBitmap, int width, int height, int zoom, int zsteps, int minDate, int maxDate) {
+            Bitmap finalBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+            int red, green, blue, pixel, alpha;
+            int[] pixels = new int[width * height];
+            scaledBitmap.getPixels(pixels, 0, width, 0, 0, width, height);
+            for (int i = 0; i < pixels.length; i++) {
+                pixel = pixels[i];
 
-            Bitmap image;
+                red = (pixel >> 16) & 0xFF;
+                green = (pixel >> 8) & 0xFF;
+                blue = pixel & 0xFF;
 
-            if (this.isConnected) {
-                String providerUrl = this.urlTemplate
-                  .replace("{x}", Integer.toString(xCord))
-                  .replace("{y}", Integer.toString(yCord))
-                  .replace("{z}", Integer.toString(zoomCord));
+                if (red > 255)
+                    red = 255;
+                if (green > 255)
+                    green = 255;
 
-                URL url;
-                try {
-                    url = new URL(providerUrl);
-                    image = BitmapFactory.decodeStream(url.openConnection().getInputStream());
-                } catch (Exception e) {
-                    e.printStackTrace();
-                    return NO_TILE;
+                int day;
+                if (this.alertType != null && this.alertType.equals("viirs")) {
+                    day = blue;
+                } else {
+                    day = red * 255 + green;
                 }
 
-            } else {
-                BitmapFactory.Options options = new BitmapFactory.Options();
-                options.inPreferredConfig = Bitmap.Config.ARGB_8888;
-                File dir = getContext().getFilesDir();
-                File myFile = new File(dir + "/tiles" + "/" + this.alertType, areaId + "/" + zoomCord + "x" + xCord + "x" + yCord + ".png");
-
-                try {
-                    image = BitmapFactory.decodeFile(myFile.getAbsolutePath(), options);
-                } catch (Exception e) {
-                    e.printStackTrace();
-
-
-                    return NO_TILE;
-                }
-            }
-
-            if (zoom > this.maxZoom) {
-                int zsteps = zoom - this.maxZoom;
-                int relation = (int) Math.pow(2, zsteps) ;
-                int size = (int) (TILE_SIZE / relation);
-                // we scale the map to keep the tiles sharp
-                scaleSize = (int) (TILE_SIZE * 2);
-                srcX = (int) size  * (x % relation);
-                srcY = (int) size  * (y % relation);
-                srcW = (int) size;
-                srcH = (int) size;
-            }
-
-            if (image != null) {
-                Bitmap croppedBitmap = Bitmap.createBitmap(image , srcX , srcY, srcW, srcH);
-                Bitmap scaledBitmap = croppedBitmap;
-                if (zoom > maxZoom) {
-                    // The last false is for filter anti-aliasing
-                    scaledBitmap = Bitmap.createScaledBitmap (croppedBitmap, scaleSize, scaleSize, false);
-                }
-
-                int width, height;
-                height = scaledBitmap.getHeight();
-                width = scaledBitmap.getWidth();
-
-                Bitmap finalBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
-                int red, green, blue, pixel, alpha;
-                int[] pixels = new int[width * height];
-                scaledBitmap.getPixels(pixels, 0, width, 0, 0, width, height);
-                for (int i = 0; i < pixels.length; i++) {
-                    pixel = pixels[i];
-
-                    red = (pixel >> 16) & 0xFF;
-                    green = (pixel >> 8) & 0xFF;
-                    blue = pixel & 0xFF;
-
-                    if (red > 255)
-                        red = 255;
-                    if (green > 255)
-                        green = 255;
-
-                    int day;
-                    if (this.alertType.equals("viirs")) {
-                        day = blue;
-                    } else {
-                        day = red * 255 + green;
-                    }
-
-                    if(this.alertType.equals("viirs")) {
-                        if (day > 0) {
-                            red = 244;
-                            green = 66;
-                            blue = 66;
-                            alpha = 255;
-                        } else {
-                            alpha = 0;
-                        }
-                    } else if (day > 0 && day >= minDate && day <= maxDate) {
-                        red = 220;
-                        green = 102;
-                        blue = 153;
+                if(this.alertType != null && this.alertType.equals("viirs")) {
+                    if (day > 0) {
+                        red = 244;
+                        green = 66;
+                        blue = 66;
                         alpha = 255;
                     } else {
                         alpha = 0;
                     }
-
-                    pixels[i] = Color.argb(alpha, red, green, blue);
+                } else if (day > 0 && day >= minDate && day <= maxDate) {
+                    red = 220;
+                    green = 102;
+                    blue = 153;
+                    alpha = 255;
+                } else {
+                    alpha = 0;
                 }
-                finalBitmap.setPixels(pixels, 0, width, 0, 0, width, height);
 
-                stream = new ByteArrayOutputStream();
-                finalBitmap.compress(Bitmap.CompressFormat.PNG, 0, stream);
-                bitmapData = stream.toByteArray();
-                return new Tile(TILE_SIZE, TILE_SIZE, bitmapData);
-            } else {
-                return NO_TILE;
+                pixels[i] = Color.argb(alpha, red, green, blue);
             }
+            finalBitmap.setPixels(pixels, 0, width, 0, 0, width, height);
+            return finalBitmap;
         }
 
-        public void setUrlTemplate(String urlTemplate) {
-            this.urlTemplate = urlTemplate;
-        }
-
-        public void setMaxZoom(int maxZoom) {
-            this.maxZoom = maxZoom;
-        }
-
-        public void setAreaId(String areaId) {
-            this.areaId = areaId;
-        }
-
-        public void setIsConnected(boolean isConnected) {
-            this.isConnected = isConnected;
-        }
-        public void setAlertType(String alertType) {
-            this.alertType = alertType;
-        }
 
     }
 
-    private TileOverlayOptions tileOverlayOptions;
-    private TileOverlay tileOverlay;
-    private AIRMapCanvasUrlTileProvider tileProvider;
 
-    private String urlTemplate;
-    private int maxZoom;
-    private String areaId;
-    private String alertType;
-    private String minDate;
-    private String maxDate;
-    private boolean isConnected;
-    private float zIndex;
-
-    public AirMapCanvasUrlTile(Context context) {
-        super(context);
-    }
-
-    public void setUrlTemplate(String urlTemplate) {
-        this.urlTemplate = urlTemplate;
-        if (tileProvider != null) {
-            tileProvider.setUrlTemplate(urlTemplate);
-        }
-        if (tileOverlay != null) {
-            tileOverlay.clearTileCache();
-        }
-    }
-
-    public void setMaxZoom(int maxZoom) {
-        this.maxZoom = maxZoom;
-        if (tileProvider != null) {
-            tileProvider.setMaxZoom(maxZoom);
-        }
-        if (tileOverlay != null) {
-            tileOverlay.clearTileCache();
-        }
-    }
-
-    public void setAreaId(String areaId) {
-        this.areaId = areaId;
-        if (tileProvider != null) {
-            tileProvider.setAreaId(areaId);
-        }
-        if (tileOverlay != null) {
-            tileOverlay.clearTileCache();
-        }
-    }
-
-    public void setIsConnected(boolean isConnected) {
-        this.isConnected = isConnected;
-        if (tileProvider != null) {
-            tileProvider.setIsConnected(isConnected);
-        }
-        if (tileOverlay != null) {
-            tileOverlay.clearTileCache();
-        }
-    }
-
-    public void setAlertType(String alertType) {
-        this.alertType = alertType;
-        if (tileProvider != null) {
-            tileProvider.setAlertType(alertType);
-        }
-        if (tileOverlay != null) {
-            tileOverlay.clearTileCache();
-        }
-    }
-
-    public void setMinDate(String minDate) {
-        this.minDate = minDate;
-    }
-
-    public void setMaxDate(String maxDate) {
-        this.maxDate = maxDate;
-    }
-
-    public void setZIndex(float zIndex) {
-        this.zIndex = zIndex;
-        if (tileOverlay != null) {
-            tileOverlay.setZIndex(zIndex);
-        }
-    }
-
-    public TileOverlayOptions getTileOverlayOptions() {
-        if (tileOverlayOptions == null) {
-            tileOverlayOptions = createTileOverlayOptions();
-        }
-        return tileOverlayOptions;
-    }
-
-    private TileOverlayOptions createTileOverlayOptions() {
+    protected TileOverlayOptions createTileOverlayOptions() {
         TileOverlayOptions options = new TileOverlayOptions();
         options.zIndex(zIndex);
-        this.tileProvider = new AIRMapCanvasUrlTileProvider(256, 256, this.urlTemplate, this.maxZoom, this.areaId, this.alertType, this.isConnected, this.minDate, this.maxDate);
+        this.tileProvider = new AIRMapCanvasUrlTileProvider(256, 256, this.urlTemplate, this.maxZoom, this.areaId,  this.isConnected, this.minDate, this.maxDate, this.alertType, null);
         options.tileProvider(this.tileProvider);
         return options;
     }
 
-    @Override
-    public Object getFeature() {
-        return tileOverlay;
-    }
-
-    @Override
-    public void addToMap(GoogleMap map) {
-        this.tileOverlay = map.addTileOverlay(getTileOverlayOptions());
-    }
-
-    @Override
-    public void removeFromMap(GoogleMap map) {
-        tileOverlay.remove();
-    }
 }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTile.java
@@ -1,0 +1,164 @@
+package com.airbnb.android.react.maps;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.net.Uri;
+import android.os.AsyncTask;
+import android.util.Log;
+import android.widget.ImageView;
+
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.Tile;
+import com.google.android.gms.maps.model.TileOverlay;
+import com.google.android.gms.maps.model.TileOverlayOptions;
+import com.google.android.gms.maps.model.TileProvider;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class AirMapCanvasUrlTile extends AirMapFeature {
+
+    class AIRMapCanvasUrlTileProvider implements TileProvider {
+        public AIRMapCanvasUrlTileProvider(int width, int height) {
+            super();
+        }
+        @Override
+        public Tile getTile(int x, int y, int zoom) {
+            int w = 256, h = 256;
+
+            Bitmap.Config conf = Bitmap.Config.ARGB_8888;
+            Bitmap coordTile = Bitmap.createBitmap(w, h, conf);
+            ByteArrayOutputStream stream = new ByteArrayOutputStream();
+            //coordTile.compress(Bitmap.CompressFormat.PNG, 100, stream);
+            byte[] bitmapData = stream.toByteArray();
+            Uri.Builder builder = new Uri.Builder();
+            builder.scheme("http")
+                    .authority("wri-tiles.s3.amazonaws.com")
+                    .appendPath("glad_prod")
+                    .appendPath("tiles")
+                    .appendPath(String.valueOf(zoom))
+                    .appendPath(String.valueOf(x))
+                    .appendPath(String.valueOf(y));
+            String providerUrl = builder.build().toString() + ".png";
+
+            Log.d("Tiles", providerUrl);
+
+
+            //new DownloadTile(bitmapData)
+            //       .execute(providerUrl);
+
+            URL url = null;
+            try {
+                url = new URL(providerUrl);
+                Bitmap image = BitmapFactory.decodeStream(url.openConnection().getInputStream());
+
+                int width, height, r,g, b, c;
+                height = image.getHeight();
+                width = image.getWidth();
+
+                Bitmap bmpSephia = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+                /*Canvas canvas = new Canvas(bmpSephia);
+                Paint paint = new Paint();
+                paint.setAntiAlias(true);
+
+                canvas.drawBitmap(image, 0, 0, paint);*/
+                /*
+                for(int e=0; e < width; e++) {
+                    for(int f=0; f < height; f++) {
+                        c = image.getPixel(e, f);
+                        int day = Color.red(c) * 255 + Color.green(c);
+
+                        if (day > 0 ) {
+                            r = 220;
+                            g = 102;
+                            b = 153;
+
+                            bmpSephia.setPixel(e, f, Color.rgb(r, g, b));
+                        } else {
+                            bmpSephia.setPixel(e, f, Color.argb(0, 0, 0 ,0));
+                        }
+                    }
+                }*/
+
+
+                stream = new ByteArrayOutputStream();
+                image.compress(Bitmap.CompressFormat.PNG, 0, stream);
+                bitmapData = stream.toByteArray();
+            } catch (MalformedURLException e) {
+                e.printStackTrace();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+            return new Tile(256, 256, bitmapData);
+        }
+    }
+
+
+    private TileOverlayOptions tileOverlayOptions;
+    private TileOverlay tileOverlay;
+
+    private String urlTemplate;
+    private float zIndex;
+
+    public AirMapCanvasUrlTile(Context context) {
+        super(context);
+    }
+
+    public void setZIndex(float zIndex) {
+        this.zIndex = zIndex;
+        if (tileOverlay != null) {
+            tileOverlay.setZIndex(zIndex);
+        }
+    }
+
+    private class DownloadTile extends AsyncTask<String, Void, Bitmap> {
+        private byte[] tile;
+
+        public DownloadTile(byte[] tile) {
+            this.tile = tile;
+        }
+
+        protected Bitmap doInBackground(String... urls) {
+            String imageURL = urls[0];
+            Bitmap bimage = null;
+            try {
+                InputStream in = new java.net.URL(imageURL).openStream();
+                bimage = BitmapFactory.decodeStream(in);
+
+            } catch (Exception e) {
+                Log.e("Error Message", e.getMessage());
+                e.printStackTrace();
+            }
+            return bimage;
+        }
+
+        protected void onPostExecute(Bitmap result) {
+            Log.d("Title", String.valueOf(result));
+            ByteArrayOutputStream stream = new ByteArrayOutputStream();
+            result.compress(Bitmap.CompressFormat.PNG, 0, stream);
+            this.tile = stream.toByteArray();
+            Tile newTile = new Tile(256, 256, this.tile);
+        }
+    }
+
+    @Override
+    public Object getFeature() {
+        return tileOverlay;
+    }
+
+    @Override
+    public void addToMap(GoogleMap map) {
+        Log.d("Map", "Add to map");
+        this.tileOverlay = map.addTileOverlay(new TileOverlayOptions().tileProvider(new AIRMapCanvasUrlTileProvider(256, 256)));
+    }
+
+    @Override
+    public void removeFromMap(GoogleMap map) {
+        tileOverlay.remove();
+    }
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTile.java
@@ -28,16 +28,18 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
         private int height;
         private int maxZoom;
         private String areaId;
+        private String alertType;
         private String minDate;
         private String maxDate;
         private boolean isConnected;
-        public AIRMapCanvasUrlTileProvider(int width, int height, String urlTemplate, int maxZoom, String areaId, boolean isConnected, String minDate, String maxDate) {
+        public AIRMapCanvasUrlTileProvider(int width, int height, String urlTemplate, int maxZoom, String areaId, String alertType, boolean isConnected, String minDate, String maxDate) {
             super();
             this.width = width;
             this.height = height;
             this.urlTemplate = urlTemplate;
             this.maxZoom = maxZoom;
             this.areaId = areaId;
+            this.alertType = alertType;
             this.isConnected = isConnected;
             this.minDate = minDate;
             this.maxDate = maxDate;
@@ -89,7 +91,7 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
                 BitmapFactory.Options options = new BitmapFactory.Options();
                 options.inPreferredConfig = Bitmap.Config.ARGB_8888;
                 File dir = getContext().getFilesDir();
-                File myFile = new File(dir + "/tiles", areaId + "/" + zoomCord + "x" + xCord + "x" + yCord + ".png");
+                File myFile = new File(dir + "/tiles", areaId + "/" + this.alertType + "/" + zoomCord + "x" + xCord + "x" + yCord + ".png");
 
                 try {
                     image = BitmapFactory.decodeFile(myFile.getAbsolutePath(), options);
@@ -119,7 +121,7 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
                     scaledBitmap = Bitmap.createScaledBitmap (croppedBitmap, scaleSize, scaleSize, false);
                 }
 
-                int width, height, r, g, b, c;
+                int width, height;
                 height = scaledBitmap.getHeight();
                 width = scaledBitmap.getWidth();
 
@@ -142,10 +144,17 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
                     int day = red * 255 + green;
 
                     if (day > 0 && day >= minDate && day <= maxDate) {
-                        red = 220;
-                        green = 102;
-                        blue = 153;
-                        alpha = 255;
+                        if (this.alertType.equals("viirs")) {
+                            red = 244;
+                            green = 66;
+                            blue = 66;
+                            alpha = 255;
+                        } else {
+                            red = 220;
+                            green = 102;
+                            blue = 153;
+                            alpha = 255;
+                        }
                     } else {
                         alpha = 0;
                     }
@@ -178,6 +187,10 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
         public void setIsConnected(boolean isConnected) {
             this.isConnected = isConnected;
         }
+        public void setAlertType(String alertType) {
+            this.alertType = alertType;
+        }
+
     }
 
     private TileOverlayOptions tileOverlayOptions;
@@ -187,6 +200,7 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
     private String urlTemplate;
     private int maxZoom;
     private String areaId;
+    private String alertType;
     private String minDate;
     private String maxDate;
     private boolean isConnected;
@@ -236,6 +250,16 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
         }
     }
 
+    public void setAlertType(String alertType) {
+        this.alertType = alertType;
+        if (tileProvider != null) {
+            tileProvider.setAlertType(alertType);
+        }
+        if (tileOverlay != null) {
+            tileOverlay.clearTileCache();
+        }
+    }
+
     public void setMinDate(String minDate) {
         this.minDate = minDate;
     }
@@ -261,7 +285,7 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
     private TileOverlayOptions createTileOverlayOptions() {
         TileOverlayOptions options = new TileOverlayOptions();
         options.zIndex(zIndex);
-        this.tileProvider = new AIRMapCanvasUrlTileProvider(256, 256, this.urlTemplate, this.maxZoom, this.areaId, this.isConnected, this.minDate, this.maxDate);
+        this.tileProvider = new AIRMapCanvasUrlTileProvider(256, 256, this.urlTemplate, this.maxZoom, this.areaId, this.alertType, this.isConnected, this.minDate, this.maxDate);
         options.tileProvider(this.tileProvider);
         return options;
     }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTile.java
@@ -32,10 +32,9 @@ public class AirMapCanvasUrlTile extends AirMapCanvasFeature {
                 green = (pixel >> 8) & 0xFF;
                 blue = pixel & 0xFF;
 
-                if (red > 255)
-                    red = 255;
-                if (green > 255)
-                    green = 255;
+                if (red > 255) red = 255;
+                if (green > 255) green = 255;
+                if (blue > 255) blue = 255;
 
                 int day;
                 if (this.alertType != null && this.alertType.equals("viirs")) {
@@ -45,7 +44,7 @@ public class AirMapCanvasUrlTile extends AirMapCanvasFeature {
                 }
 
                 if(this.alertType != null && this.alertType.equals("viirs")) {
-                    if (day > 0) {
+                    if (day > 0 && day >= minDate && day <= maxDate) {
                         red = 244;
                         green = 66;
                         blue = 66;

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTile.java
@@ -84,7 +84,7 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
                 BitmapFactory.Options options = new BitmapFactory.Options();
                 options.inPreferredConfig = Bitmap.Config.ARGB_8888;
                 File dir = getContext().getFilesDir();
-                File myFile = new File(dir, "tiles/" + areaId + "/" + zoomCord + "x" + xCord + "x" + yCord + ".png");
+                File myFile = new File(dir + "/tiles", areaId + "/" + zoomCord + "x" + xCord + "x" + yCord + ".png");
 
                 try {
                     image = BitmapFactory.decodeFile(myFile.getAbsolutePath(), options);

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTile.java
@@ -43,14 +43,11 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
                 zoomCord = maxZoom;
             }
 
-
-
             Bitmap.Config conf = Bitmap.Config.ARGB_8888;
-            Bitmap coordTile = Bitmap.createBitmap(w, h, conf);
             ByteArrayOutputStream stream = new ByteArrayOutputStream();
-            //coordTile.compress(Bitmap.CompressFormat.PNG, 100, stream);
             byte[] bitmapData = stream.toByteArray();
             Uri.Builder builder = new Uri.Builder();
+
             builder.scheme("http")
                     .authority("wri-tiles.s3.amazonaws.com")
                     .appendPath("glad_prod")
@@ -59,8 +56,6 @@ public class AirMapCanvasUrlTile extends AirMapFeature {
                     .appendPath(String.valueOf(xCord))
                     .appendPath(String.valueOf(yCord));
             String providerUrl = builder.build().toString() + ".png";
-
-            Log.d("Tiles", providerUrl);
 
             int srcX = 0;
             int srcY = 0;

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTileManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTileManager.java
@@ -28,7 +28,6 @@ public class AirMapCanvasUrlTileManager extends ViewGroupManager<AirMapCanvasUrl
 
     @Override
     public String getName() {
-        Log.d("Map", "Get name");
         return "AIRMapCanvasUrlTile";
     }
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTileManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTileManager.java
@@ -47,9 +47,9 @@ public class AirMapCanvasUrlTileManager extends ViewGroupManager<AirMapCanvasUrl
         view.setMaxZoom(maxZoom);
     }
 
-    @ReactProp(name = "areaName")
-    public void setAreaName(AirMapCanvasUrlTile view, String areaName) {
-        view.setAreaName(areaName);
+    @ReactProp(name = "areaId")
+    public void setAreaId(AirMapCanvasUrlTile view, String areaId) {
+        view.setAreaId(areaId);
     }
 
     @ReactProp(name = "isConnected", defaultBoolean = true)

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTileManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTileManager.java
@@ -1,0 +1,50 @@
+package com.airbnb.android.react.maps;
+
+import android.content.Context;
+import android.os.Build;
+import android.util.DisplayMetrics;
+import android.util.Log;
+import android.view.WindowManager;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
+
+public class AirMapCanvasUrlTileManager extends ViewGroupManager<AirMapCanvasUrlTile> {
+    private DisplayMetrics metrics;
+
+    public AirMapCanvasUrlTileManager(ReactApplicationContext reactContext) {
+        super();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            metrics = new DisplayMetrics();
+            ((WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE))
+                    .getDefaultDisplay()
+                    .getRealMetrics(metrics);
+        } else {
+            metrics = reactContext.getResources().getDisplayMetrics();
+        }
+    }
+
+    @Override
+    public String getName() {
+        Log.d("Map", "Get name");
+        return "AIRMapCanvasUrlTile";
+    }
+
+    @Override
+    public AirMapCanvasUrlTile createViewInstance(ThemedReactContext context) {
+        return new AirMapCanvasUrlTile(context);
+    }
+
+    @ReactProp(name = "urlTemplate")
+    public void setUrlTemplate(AirMapCanvasUrlTile view, String urlTemplate) {
+        /*view.setUrlTemplate(urlTemplate);*/
+    }
+
+    @ReactProp(name = "zIndex", defaultFloat = -1.0f)
+    public void setZIndex(AirMapCanvasUrlTile view, float zIndex) {
+        view.setZIndex(zIndex);
+    }
+
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTileManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTileManager.java
@@ -47,6 +47,11 @@ public class AirMapCanvasUrlTileManager extends ViewGroupManager<AirMapCanvasUrl
         view.setMaxZoom(maxZoom);
     }
 
+    @ReactProp(name = "alertType")
+    public void setAlertType(AirMapCanvasUrlTile view, String alertType) {
+        view.setAlertType(alertType);
+    }
+
     @ReactProp(name = "areaId")
     public void setAreaId(AirMapCanvasUrlTile view, String areaId) {
         view.setAreaId(areaId);

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTileManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapCanvasUrlTileManager.java
@@ -39,7 +39,32 @@ public class AirMapCanvasUrlTileManager extends ViewGroupManager<AirMapCanvasUrl
 
     @ReactProp(name = "urlTemplate")
     public void setUrlTemplate(AirMapCanvasUrlTile view, String urlTemplate) {
-        /*view.setUrlTemplate(urlTemplate);*/
+        view.setUrlTemplate(urlTemplate);
+    }
+
+    @ReactProp(name = "maxZoom", defaultInt = 12)
+    public void setMaxZoom(AirMapCanvasUrlTile view, int maxZoom) {
+        view.setMaxZoom(maxZoom);
+    }
+
+    @ReactProp(name = "areaName")
+    public void setAreaName(AirMapCanvasUrlTile view, String areaName) {
+        view.setAreaName(areaName);
+    }
+
+    @ReactProp(name = "isConnected", defaultBoolean = true)
+    public void setIsConnected(AirMapCanvasUrlTile view, boolean isConnected) {
+        view.setIsConnected(isConnected);
+    }
+
+    @ReactProp(name = "minDate")
+    public void setMinDate(AirMapCanvasUrlTile view, String minDate) {
+        view.setMinDate(minDate);
+    }
+
+    @ReactProp(name = "maxDate")
+    public void setMaxDate(AirMapCanvasUrlTile view, String maxDate) {
+        view.setMaxDate(maxDate);
     }
 
     @ReactProp(name = "zIndex", defaultFloat = -1.0f)

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -10,6 +10,7 @@ import android.os.Build;
 import android.os.Handler;
 import android.support.v4.view.GestureDetectorCompat;
 import android.support.v4.view.MotionEventCompat;
+import android.util.Log;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
@@ -428,6 +429,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     public void addFeature(View child, int index) {
         // Our desired API is to pass up annotations/overlays as children to the mapview component.
         // This is where we intercept them and do the appropriate underlying mapview action.
+
         if (child instanceof AirMapMarker) {
             AirMapMarker annotation = (AirMapMarker) child;
             annotation.addToMap(map);
@@ -454,6 +456,10 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
             AirMapUrlTile urlTileView = (AirMapUrlTile) child;
             urlTileView.addToMap(map);
             features.add(index, urlTileView);
+        } else if (child instanceof AirMapCanvasUrlTile) {
+          AirMapCanvasUrlTile canvasUrlTileView = (AirMapCanvasUrlTile) child;
+          canvasUrlTileView.addToMap(map);
+          features.add(index, canvasUrlTileView);
         } else {
             ViewGroup children = (ViewGroup) child;
             for (int i = 0; i < children.getChildCount(); i++) {

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -460,6 +460,10 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
             AirMapCanvasUrlTile canvasUrlTileView = (AirMapCanvasUrlTile) child;
             canvasUrlTileView.addToMap(map);
             features.add(index, canvasUrlTileView);
+        } else if (child instanceof AirMapCanvasInteractionUrlTile) {
+            AirMapCanvasInteractionUrlTile canvasInteractionUrlTileView = (AirMapCanvasInteractionUrlTile) child;
+            canvasInteractionUrlTileView.addToMap(map);
+            features.add(index, canvasInteractionUrlTileView);
         } else {
             ViewGroup children = (ViewGroup) child;
             for (int i = 0; i < children.getChildCount(); i++) {

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -457,9 +457,9 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
             urlTileView.addToMap(map);
             features.add(index, urlTileView);
         } else if (child instanceof AirMapCanvasUrlTile) {
-          AirMapCanvasUrlTile canvasUrlTileView = (AirMapCanvasUrlTile) child;
-          canvasUrlTileView.addToMap(map);
-          features.add(index, canvasUrlTileView);
+            AirMapCanvasUrlTile canvasUrlTileView = (AirMapCanvasUrlTile) child;
+            canvasUrlTileView.addToMap(map);
+            features.add(index, canvasUrlTileView);
         } else {
             ViewGroup children = (ViewGroup) child;
             for (int i = 0; i < children.getChildCount(); i++) {

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/Coordinates.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/Coordinates.java
@@ -1,0 +1,22 @@
+package com.airbnb.android.react.maps;
+
+/**
+ * Created by joseangel on 25/05/2017.
+ */
+
+public class Coordinates {
+    private int[] tile;
+    private double[] precision;
+
+    public Coordinates(int[] tile, double[] precision) {
+        this.tile = tile;
+        this.precision = precision;
+    }
+
+    public int[] getTile() {
+        return tile;
+    }
+    public double[] getPrecision() {
+        return precision;
+    }
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
@@ -39,6 +39,7 @@ public class MapsPackage implements ReactPackage {
         AirMapManager mapManager = new AirMapManager(reactContext);
         AirMapLiteManager mapLiteManager = new AirMapLiteManager(reactContext);
         AirMapUrlTileManager tileManager = new AirMapUrlTileManager(reactContext);
+        AirMapCanvasUrlTileManager canvasTileManager = new AirMapCanvasUrlTileManager(reactContext);
 
         return Arrays.<ViewManager>asList(
                 calloutManager,
@@ -48,6 +49,7 @@ public class MapsPackage implements ReactPackage {
                 circleManager,
                 mapManager,
                 mapLiteManager,
-                tileManager);
+                tileManager,
+                canvasTileManager);
     }
 }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
@@ -40,6 +40,7 @@ public class MapsPackage implements ReactPackage {
         AirMapLiteManager mapLiteManager = new AirMapLiteManager(reactContext);
         AirMapUrlTileManager tileManager = new AirMapUrlTileManager(reactContext);
         AirMapCanvasUrlTileManager canvasTileManager = new AirMapCanvasUrlTileManager(reactContext);
+        AirMapCanvasInteractionUrlTileManager canvasInteractionTileManager = new AirMapCanvasInteractionUrlTileManager(reactContext);
 
         return Arrays.<ViewManager>asList(
                 calloutManager,
@@ -50,6 +51,7 @@ public class MapsPackage implements ReactPackage {
                 mapManager,
                 mapLiteManager,
                 tileManager,
-                canvasTileManager);
+                canvasTileManager,
+                canvasInteractionTileManager);
     }
 }

--- a/lib/components/MapCanvasInteractionUrlTile.js
+++ b/lib/components/MapCanvasInteractionUrlTile.js
@@ -54,9 +54,8 @@ const propTypes = {
    * Max zoom when the tiles have data
    */
   coordinates: PropTypes.shape({
-    latitud: PropTypes.number,
-    longitud: PropTypes.number,
     tile: PropTypes.arrayOf(React.PropTypes.number),
+    precision: PropTypes.arrayOf(React.PropTypes.number),
   }),
 };
 

--- a/lib/components/MapCanvasInteractionUrlTile.js
+++ b/lib/components/MapCanvasInteractionUrlTile.js
@@ -1,0 +1,91 @@
+import React, { PropTypes } from 'react';
+
+import {
+  View,
+} from 'react-native';
+
+import decorateMapComponent, {
+  USES_DEFAULT_IMPLEMENTATION,
+  SUPPORTED,
+} from './decorateMapComponent';
+
+const viewConfig = {
+  uiViewClassName: 'AIR<provider>CanvasInteractionUrlTile',
+};
+
+const propTypes = {
+  ...View.propTypes,
+
+  /**
+   * The url template of the tile server. The patterns {x} {y} {z} will be replaced at runtime
+   * For example, http://c.tile.openstreetmap.org/{z}/{x}/{y}.png
+   */
+  urlTemplate: PropTypes.string.isRequired,
+
+  /**
+   * The order in which this tile overlay is drawn with respect to other overlays. An overlay
+   * with a larger z-index is drawn over overlays with smaller z-indices. The order of overlays
+   * with the same z-index is arbitrary. The default zIndex is -1.
+   *
+   * @platform android
+   */
+  zIndex: PropTypes.number,
+  /**
+   * Flag to use the offline tiles instead of the url version
+   */
+  isConnected: PropTypes.bool,
+  /**
+   * Area id to get the tiles from the corrent folder
+   */
+  areaId: PropTypes.string,
+  /**
+   * Min date to get tiles
+   */
+  minDate: PropTypes.string,
+  /**
+   * Max date to get tiles
+   */
+  maxDate: PropTypes.string,
+  /**
+   * Max zoom when the tiles have data
+   */
+  maxZoom: PropTypes.number,
+  /**
+   * Max zoom when the tiles have data
+   */
+  coordinates: PropTypes.shape({
+    latitud: PropTypes.number,
+    longitud: PropTypes.number,
+    tile: PropTypes.arrayOf(React.PropTypes.number),
+  }),
+};
+
+const defaultProps = {
+  maxZoom: 12,
+  isConnected: true,
+};
+
+class CanvasInteractionUrlTile extends React.Component {
+  render() {
+    const AIRMapCanvasInteractionUrlTile = this.getAirComponent();
+    return (
+      <AIRMapCanvasInteractionUrlTile
+        {...this.props}
+      />
+    );
+  }
+}
+
+CanvasInteractionUrlTile.viewConfig = viewConfig;
+CanvasInteractionUrlTile.propTypes = propTypes;
+CanvasInteractionUrlTile.defaultProps = defaultProps;
+
+module.exports = decorateMapComponent(CanvasInteractionUrlTile, {
+  componentType: 'CanvasInteractionUrlTile',
+  providers: {
+    google: {
+      ios: SUPPORTED,
+      android: USES_DEFAULT_IMPLEMENTATION,
+    },
+  },
+});

--- a/lib/components/MapCanvasUrlTile.js
+++ b/lib/components/MapCanvasUrlTile.js
@@ -35,9 +35,9 @@ const propTypes = {
    */
   isConnected: PropTypes.bool,
   /**
-   * Area name to get the tiles from the corrent folder
+   * Area id to get the tiles from the corrent folder
    */
-  areaName: PropTypes.string,
+  areaId: PropTypes.string,
   /**
    * Min date to get tiles
    */

--- a/lib/components/MapCanvasUrlTile.js
+++ b/lib/components/MapCanvasUrlTile.js
@@ -11,9 +11,6 @@ import decorateMapComponent, {
 
 const viewConfig = {
   uiViewClassName: 'AIR<provider>CanvasUrlTile',
-  validAttributes: {
-    coordinate: true,
-  },
 };
 
 const propTypes = {

--- a/lib/components/MapCanvasUrlTile.js
+++ b/lib/components/MapCanvasUrlTile.js
@@ -39,6 +39,10 @@ const propTypes = {
    */
   areaId: PropTypes.string,
   /**
+   * Alert type supported umd_as_it_happens OR viirs
+   */
+  alertType: PropTypes.string,
+  /**
    * Min date to get tiles
    */
   minDate: PropTypes.string,

--- a/lib/components/MapCanvasUrlTile.js
+++ b/lib/components/MapCanvasUrlTile.js
@@ -26,22 +26,42 @@ const propTypes = {
    * @platform android
    */
   zIndex: PropTypes.number,
+  /**
+   * Flag to use the offline tiles instead of the url version
+   */
+  isConnected: PropTypes.bool,
+  /**
+   * Area name to get the tiles from the corrent folder
+   */
+  areaName: PropTypes.string,
+  /**
+   * Min date to get tiles
+   */
+  minDate: PropTypes.string,
+  /**
+   * Max date to get tiles
+   */
+  maxDate: PropTypes.string,
+  /**
+   * Max zoom when the tiles have data
+   */
+  maxZoom: PropTypes.number,
 };
 
-class MapUrlTile extends React.Component {
+class CanvasUrlTile extends React.Component {
   render() {
-    const AIRMapUrlTile = this.getAirComponent();
+    const AIRMapCanvasUrlTile = this.getAirComponent();
     return (
-      <AIRMapUrlTile
+      <AIRMapCanvasUrlTile
         {...this.props}
       />
     );
   }
 }
 
-MapUrlTile.propTypes = propTypes;
+CanvasUrlTile.propTypes = propTypes;
 
-module.exports = decorateMapComponent(MapUrlTile, {
+module.exports = decorateMapComponent(CanvasUrlTile, {
   componentType: 'CanvasUrlTile',
   providers: {
     google: {

--- a/lib/components/MapCanvasUrlTile.js
+++ b/lib/components/MapCanvasUrlTile.js
@@ -9,6 +9,13 @@ import decorateMapComponent, {
   SUPPORTED,
 } from './decorateMapComponent';
 
+const viewConfig = {
+  uiViewClassName: 'AIR<provider>CanvasUrlTile',
+  validAttributes: {
+    coordinate: true,
+  },
+};
+
 const propTypes = {
   ...View.propTypes,
 
@@ -48,6 +55,11 @@ const propTypes = {
   maxZoom: PropTypes.number,
 };
 
+const defaultProps = {
+  maxZoom: 12,
+  isConnected: true,
+};
+
 class CanvasUrlTile extends React.Component {
   render() {
     const AIRMapCanvasUrlTile = this.getAirComponent();
@@ -59,7 +71,9 @@ class CanvasUrlTile extends React.Component {
   }
 }
 
+CanvasUrlTile.viewConfig = viewConfig;
 CanvasUrlTile.propTypes = propTypes;
+CanvasUrlTile.defaultProps = defaultProps;
 
 module.exports = decorateMapComponent(CanvasUrlTile, {
   componentType: 'CanvasUrlTile',

--- a/lib/components/MapCanvasUrlTile.js
+++ b/lib/components/MapCanvasUrlTile.js
@@ -1,0 +1,52 @@
+import React, { PropTypes } from 'react';
+
+import {
+  View,
+} from 'react-native';
+
+import decorateMapComponent, {
+  USES_DEFAULT_IMPLEMENTATION,
+  SUPPORTED,
+} from './decorateMapComponent';
+
+const propTypes = {
+  ...View.propTypes,
+
+  /**
+   * The url template of the tile server. The patterns {x} {y} {z} will be replaced at runtime
+   * For example, http://c.tile.openstreetmap.org/{z}/{x}/{y}.png
+   */
+  urlTemplate: PropTypes.string.isRequired,
+
+  /**
+   * The order in which this tile overlay is drawn with respect to other overlays. An overlay
+   * with a larger z-index is drawn over overlays with smaller z-indices. The order of overlays
+   * with the same z-index is arbitrary. The default zIndex is -1.
+   *
+   * @platform android
+   */
+  zIndex: PropTypes.number,
+};
+
+class MapUrlTile extends React.Component {
+  render() {
+    const AIRMapUrlTile = this.getAirComponent();
+    return (
+      <AIRMapUrlTile
+        {...this.props}
+      />
+    );
+  }
+}
+
+MapUrlTile.propTypes = propTypes;
+
+module.exports = decorateMapComponent(MapUrlTile, {
+  componentType: 'CanvasUrlTile',
+  providers: {
+    google: {
+      ios: SUPPORTED,
+      android: USES_DEFAULT_IMPLEMENTATION,
+    },
+  },
+});

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -16,6 +16,7 @@ import MapCircle from './MapCircle';
 import MapCallout from './MapCallout';
 import MapUrlTile from './MapUrlTile';
 import MapCanvasUrlTile from './MapCanvasUrlTile';
+import MapCanvasInteractionUrlTile from './MapCanvasInteractionUrlTile';
 import AnimatedRegion from './AnimatedRegion';
 import {
   contextTypes as childContextTypes,
@@ -682,6 +683,7 @@ MapView.Polygon = MapPolygon;
 MapView.Circle = MapCircle;
 MapView.UrlTile = MapUrlTile;
 MapView.CanvasUrlTile = MapCanvasUrlTile;
+MapView.CanvasInteractionUrlTile = MapCanvasInteractionUrlTile;
 MapView.Callout = MapCallout;
 Object.assign(MapView, ProviderConstants);
 MapView.ProviderPropType = PropTypes.oneOf(Object.values(ProviderConstants));

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -15,6 +15,7 @@ import MapPolygon from './MapPolygon';
 import MapCircle from './MapCircle';
 import MapCallout from './MapCallout';
 import MapUrlTile from './MapUrlTile';
+import MapCanvasUrlTile from './MapCanvasUrlTile';
 import AnimatedRegion from './AnimatedRegion';
 import {
   contextTypes as childContextTypes,
@@ -680,6 +681,7 @@ MapView.Polyline = MapPolyline;
 MapView.Polygon = MapPolygon;
 MapView.Circle = MapCircle;
 MapView.UrlTile = MapUrlTile;
+MapView.CanvasUrlTile = MapCanvasUrlTile;
 MapView.Callout = MapCallout;
 Object.assign(MapView, ProviderConstants);
 MapView.ProviderPropType = PropTypes.oneOf(Object.values(ProviderConstants));

--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
   },
   "dependencies": {
     "@mapbox/geo-viewport": "^0.2.2",
-    "@mapbox/tilebelt": "^1.0.1"
+    "@mapbox/tilebelt": "Vizzuality/tilebelt"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,5 +55,9 @@
     "android": {
       "sourceDir": "./android"
     }
+  },
+  "dependencies": {
+    "@mapbox/geo-viewport": "^0.2.2",
+    "@mapbox/tilebelt": "^1.0.1"
   }
 }


### PR DESCRIPTION
This PR includes the custom Canvas Android implementation what adds the below features, ONLY IN ANDROID, TODO: IOS
- Offline support,
- Custom canvas filter by dates layer.
- New interaction layer to highlight the area selected (TODO: improve the highlight size in zoom level changes)

This component extends the UrlTile one and receives the following new params:
- areaId: necessary to generate the cached folder.
- alertType: supports VIIRS("viirs") and GLAD ("umd_as_it_happens") layers, also mandatory for the cached folder.
- isConnected: gets the online status in the app to get from the server or from the cached folder
- min and maxDate: dates with the days count from the origin in GLAD('20150101') and 1(today)-8(last-week) to VIIRS.


